### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ $ gem install googleauth
 require 'googleauth'
 
 # Get the environment configured authorization
-scope = 'https://www.googleapis.com/auth/userinfo.profile'
-authorization = Google::Auth.get_application_default(scope)
+scopes =  ['https://www.googleapis.com/auth/cloud-platform', 'https://www.googleapis.com/auth/compute']
+authorization = Google::Auth.get_application_default(scopes)
 
 # Add the the access token obtained using the authorization to a hash, e.g
 # headers.


### PR DESCRIPTION
1. Application default credentials is applicable to the Service Account / Robot Auth scenario. Hence updating the example snippet to use a robot scopes instead of a user scope. 
2. Updating the scope variable to the plural form scopes to reflect the usage of multiple scopes. 
