### PR TITLE
Fix 'raise_error' WARNINGs.

### DIFF
--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -58,8 +58,8 @@ describe '#get_application_default' do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, 'does-not-exist')
         ENV[@var_name] = key_path
-        expect { Google::Auth.get_application_default(@scope) }.
-          to raise_error RuntimeError
+        expect { Google::Auth.get_application_default(@scope) }
+          .to raise_error RuntimeError
       end
     end
 

--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -58,7 +58,8 @@ describe '#get_application_default' do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, 'does-not-exist')
         ENV[@var_name] = key_path
-        expect { Google::Auth.get_application_default(@scope) }.to raise_error
+        expect { Google::Auth.get_application_default(@scope) }.
+          to raise_error RuntimeError
       end
     end
 
@@ -79,7 +80,7 @@ describe '#get_application_default' do
         blk = proc do
           Google::Auth.get_application_default(@scope, connection: c)
         end
-        expect(&blk).to raise_error
+        expect(&blk).to raise_error RuntimeError
       end
       stubs.verify_stubbed_calls
     end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -182,7 +182,7 @@ describe Google::Auth::ServiceAccountCredentials do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, 'does-not-exist')
         ENV[@var_name] = key_path
-        expect { @clz.from_env(@scope) }.to raise_error
+        expect { @clz.from_env(@scope) }.to raise_error RuntimeError
       end
     end
 
@@ -285,7 +285,7 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, 'does-not-exist')
         ENV[@var_name] = key_path
-        expect { clz.from_env }.to raise_error
+        expect { clz.from_env }.to raise_error RuntimeError
       end
     end
 

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -108,7 +108,7 @@ describe Google::Auth::UserRefreshCredentials do
       Dir.mktmpdir do |dir|
         key_path = File.join(dir, 'does-not-exist')
         ENV[@var_name] = key_path
-        expect { @clz.from_env(@scope) }.to raise_error
+        expect { @clz.from_env(@scope) }.to raise_error RuntimeError
       end
     end
 
@@ -120,7 +120,7 @@ describe Google::Auth::UserRefreshCredentials do
           FileUtils.mkdir_p(File.dirname(key_path))
           File.write(key_path, cred_json_text(missing))
           ENV[@var_name] = key_path
-          expect { @clz.from_env(@scope) }.to raise_error
+          expect { @clz.from_env(@scope) }.to raise_error RuntimeError
         end
       end
     end
@@ -170,7 +170,8 @@ describe Google::Auth::UserRefreshCredentials do
           FileUtils.mkdir_p(File.dirname(key_path))
           File.write(key_path, cred_json_text(missing))
           ENV['HOME'] = dir
-          expect { @clz.from_well_known_path(@scope) }.to raise_error
+          expect { @clz.from_well_known_path(@scope) }.
+            to raise_error RuntimeError
         end
       end
     end

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -170,8 +170,8 @@ describe Google::Auth::UserRefreshCredentials do
           FileUtils.mkdir_p(File.dirname(key_path))
           File.write(key_path, cred_json_text(missing))
           ENV['HOME'] = dir
-          expect { @clz.from_well_known_path(@scope) }.
-            to raise_error RuntimeError
+          expect { @clz.from_well_known_path(@scope) }
+            .to raise_error RuntimeError
         end
       end
     end


### PR DESCRIPTION
rspec spews a warning when using raise_error without a specific error;
add "RuntimeError" to all of these occurrences.