### PR TITLE
Fix a failing test introduced in #28.

### DIFF
--- a/spec/googleauth/get_application_default_spec.rb
+++ b/spec/googleauth/get_application_default_spec.rb
@@ -195,6 +195,8 @@ describe '#get_application_default' do
         client_secret: 'privatekey',
         refresh_token: 'refreshtoken',
         client_id: 'app.apps.googleusercontent.com',
+        private_key: @key.to_pem,
+        client_email: 'app@developer.gserviceaccount.com',
         type: 'not_known_type'
       }
     end


### PR DESCRIPTION
The environment variables in the 'fails if env vars are set' test
were not actually being set because they used a nonexistent hash key
(which has the effect of unsetting the environment variable).