### PR TITLE
Updated UserRefreshCredentials hash to use string keys

### DIFF
--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -67,9 +67,9 @@ module Google
         json_key_io, scope = options.values_at(:json_key_io, :scope)
         user_creds = self.class.read_json_key(json_key_io) if json_key_io
         user_creds ||= {
-          client_id: ENV[CredentialsLoader::CLIENT_ID_VAR],
-          client_secret: ENV[CredentialsLoader::CLIENT_SECRET_VAR],
-          refresh_token: ENV[CredentialsLoader::REFRESH_TOKEN_VAR]
+          'client_id' => ENV[CredentialsLoader::CLIENT_ID_VAR],
+          'client_secret' => ENV[CredentialsLoader::CLIENT_SECRET_VAR],
+          'refresh_token' => ENV[CredentialsLoader::REFRESH_TOKEN_VAR]
         }
 
         super(token_credential_uri: TOKEN_CRED_URI,

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -141,7 +141,11 @@ describe Google::Auth::UserRefreshCredentials do
       ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
       ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
       ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
-      expect(@clz.from_env(@scope)).to_not be_nil
+      creds = @clz.from_env(@scope)
+      expect(creds).to_not be_nil
+      expect(creds.client_id).to_not be_nil
+      expect(creds.client_secret).to_not be_nil
+      expect(creds.refresh_token).to_not be_nil
     end
   end
 


### PR DESCRIPTION
Fixed an issue I introduced in google/google-auth-library-ruby@5061fb5add07035695c742d977808639f7155bef where the `user_creds` default hash used symbol instead of string keys. 
Updated a test.