### PR TITLE
fix typo of a contributor's name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Changes
 
-* Updated UserRefreshCredentials hash to use string keys ([@haabator][])
+* Updated UserRefreshCredentials hash to use string keys ([@haabaato][])
 [#36](https://github.com/google/google-auth-library-ruby/issues/36)
 
 * Add support for a system default credentials file. ([@mr-salty][])


### PR DESCRIPTION
You referred non-existing person.
https://github.com/haabator
↓
https://github.com/haabaato