### PR TITLE
Initial pass at 3LO support + migration of features from google-api-r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *~
 Gemfile.lock
 *.gem

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'signet', '~> 0.6'
+  s.add_dependency 'launchy', '~> 2.4'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   s.add_development_dependency 'simplecov', '~> 0.9'
@@ -39,4 +40,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rubocop', '~> 0.30'
   s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'redis', '~> 3.2'
+  s.add_development_dependency 'fakeredis', '~> 0.5'
+  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'sinatra', '~> 1.4'
+  s.add_development_dependency 'activerecord', '~> 4.2'
+  s.add_development_dependency 'sqlite3', '~> 1.3'
+  s.add_development_dependency 'rack-test', '~> 0.6'
 end

--- a/lib/generators/googleauth/googleauth_generator.rb
+++ b/lib/generators/googleauth/googleauth_generator.rb
@@ -1,0 +1,26 @@
+# Rails generator for configuring the google auth library for Rails. Performs the following actions
+#
+# - Creates a route for "/oauth2callback' in `config/routes.rb` for the 3LO callback handler
+# - Generates a migration for storing user credentials via ActiveRecord
+# - Creates an initializer for further customization
+#
+class GoogleauthGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+  class_option :generate_route, :type => :boolean, :default => true, :description => "Whether or not to insert routes in config/routes.rb"
+  class_option :generate_migration, :type => :boolean, :default => true, :description => "Whether or not to generate a migration for token storage"
+  class_option :generate_initializer, :type => :boolean, :default => true, :description => "Wheter or not to generate an initializer"
+
+  def generate_config
+    route "match '/oauth2callback', to: Google::Auth::AuthCallbackApp, via: :all" unless options.skip_route
+    generate "migration", "CreateGoogleAuthTokens user_id:string:index token:string" unless options.skip_migration
+    copy_file "googleauth.rb", "config/initializers/googleauth.rb" unless options.skip_initializer
+    if !client_secret_exists?
+      say "Please download your application credentials from http://console.developers.google.com and copy to config/client_secret.json."
+    end
+  end
+
+  def client_secret_exists?
+    path = File.join(Rails.root, 'config', 'client_secret.json')
+    File.exists?(path)
+  end
+end

--- a/lib/generators/googleauth/templates/googleauth.rb
+++ b/lib/generators/googleauth/templates/googleauth.rb
@@ -1,0 +1,25 @@
+# Default token store uses ActiveRecord. Use the following to use Redis instead
+#
+# Rails.application.config.googleauth.token_store = :redis
+# Rails.application.config.googleauth.token_store_options = {
+#  :url => 'redis://localhost:6380'
+# }
+
+# Default client secret location is config/client_secret.json. Alternate
+# locations can be specified as:
+# Rails.application.config.googleauth.client_secret_path = '/etc/googleauth/client_secret.json'
+#
+# Or configured directly:
+#  Rails.application.config.googleauth.id = 'myclientsecret'
+# Rails.application.config.googleauth.secret = 'mysecret'
+
+# Default scopes to request
+# Rails.application.config.googleauth.scope = %w(email profile)
+
+# Redirect URI path
+# Rails.application.config.googleauth.callback_uri = '/oauth2callback'
+
+# Uncommment to disable automatic injection of helpers into controllers.
+# If disabled, helpers can me added as needed by
+# including the module 'Google::Auth::ControllerHelpers'
+# Rails.application.config.googleauth.include_helpers = false

--- a/lib/googleauth.rb
+++ b/lib/googleauth.rb
@@ -34,6 +34,12 @@ require 'googleauth/credentials_loader'
 require 'googleauth/compute_engine'
 require 'googleauth/service_account'
 require 'googleauth/user_refresh'
+require 'googleauth/client_id'
+require 'googleauth/user_authorizer'
+require 'googleauth/web_user_authorizer'
+require 'googleauth/installed_app_user_authorizer'
+require 'googleauth/rails/auth_callback_app'
+require 'googleauth/rails/railtie' if defined?(Rails)
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization
@@ -56,11 +62,11 @@ END
         json_key_io, scope = options.values_at(:json_key_io, :scope)
         if json_key_io
           json_key, clz = determine_creds_class(json_key_io)
-          clz.new(json_key_io: StringIO.new(MultiJson.dump(json_key)),
-                  scope: scope)
+          clz.make_creds(json_key_io: StringIO.new(MultiJson.dump(json_key)),
+                         scope: scope)
         else
           clz = read_creds
-          clz.new(scope: scope)
+          clz.make_creds(scope: scope)
         end
       end
 
@@ -116,6 +122,7 @@ END
       fail NOT_FOUND_ERROR unless GCECredentials.on_gce?(options)
       GCECredentials.new
     end
+
 
     module_function :get_application_default
   end

--- a/lib/googleauth/client_id.rb
+++ b/lib/googleauth/client_id.rb
@@ -1,0 +1,98 @@
+# Copyright 2014, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'multi_json'
+
+module Google
+  module Auth
+    # Representation of an application's identity for user authorization
+    # flows.
+    class ClientId
+      INSTALLED_APP = 'installed'
+      WEB_APP = 'web'
+      CLIENT_ID = 'client_id'
+      CLIENT_SECRET = 'client_secret'
+      
+      # Text identifier of the client ID
+      # @return [String]
+      attr_reader :id
+      
+      # Secret associated with the client ID
+      # @return [String]
+      attr_reader :secret
+
+      class << self
+        attr_accessor :default
+      end
+      
+      # Initialize the Client ID
+      #
+      # @param [String] id
+      #  Text identifier of the client ID
+      # @param [String] secret
+      #  Secret associated with the client ID
+      # @note Direction instantion is discouraged to avoid embedding IDs & secrets
+      #       in source. See {#from_file} to load from `client_secrets.json` files.
+      def initialize(id, secret)
+        fail "Client id can not be nil" if id.nil?
+        fail "Client secret can not be nil" if secret.nil?
+        @id = id
+        @secret = secret
+      end
+      
+      # Constructs a Client ID from a JSON file downloaed from the Google Developers Console.
+      #
+      # @param [String, File] file
+      #  Path of file to read from
+      # @return [Google::Auth::ClientID]
+      def self.from_file(file)
+        fail "File can not be nil." if file.nil?
+        return File.open(file.to_s) do |f|
+          json = f.read
+          config = MultiJson.load(json)
+          self.from_hash(config)
+        end        
+      end
+
+      # Constructs a Client ID from a previously loaded JSON file. The hash structure should
+      # match the expected JSON format.
+      #
+      # @param [hash] config
+      #  Parsed contents of the JSON file
+      # @return [Google::Auth::ClientID]
+      # @see {https://developers.google.com/api-client-library/ruby/guide/aaa_client_secrets}
+      def self.from_hash(config)
+        fail "Hash can not be nil." if config.nil?
+        raw_detail = config[INSTALLED_APP] || config[WEB_APP]
+        fail "Expected top level property '#{INSTALLED_APP}' or '#{WEB_APP}' to be present." if raw_detail.nil?
+        ClientId.new(raw_detail[CLIENT_ID], raw_detail[CLIENT_SECRET])
+      end      
+    end
+  end
+end

--- a/lib/googleauth/installed_app_user_authorizer.rb
+++ b/lib/googleauth/installed_app_user_authorizer.rb
@@ -1,0 +1,153 @@
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'webrick'
+require 'launchy'
+
+module Google
+  module Auth
+    # Varation on {Google::Auth::UserAuthorizer} adapted command line
+    # scripts. Requests that require authorization will start an embedded
+    # web server on localhost and launch the user's browser.
+    #
+    # Example usage using browser/embedded server:
+    #
+    #     credentials = authorizer.get_credentials('example@gmail.com')
+    #
+    # If unable to launch a browser locally, a block can be supplied to
+    # handle the authorization out of band.
+    #
+    # Example of out of band authorization:
+    #
+    #     credentials = authorizer.get_credentials('example@gmail.com') do |url|
+    #       puts "Open #{url} and enter the authorization code here after authorizing the application."
+    #       gets
+    #     end
+    #
+    # @see {Google::Auth::AuthCallbackApp}
+    # @note Requires sessions are enabled
+    class InstalledAppUserAuthorizer < Google::Auth::UserAuthorizer
+      OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+      attr_accessor :local_port
+
+      # Initialize the authorizer
+      #
+      # @param [Google::Auth::ClientID] client_id
+      #  Configured ID & secret for this application
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request
+      # @param [Google::Auth::Stores::TokenStore] token_store
+      #  Backing storage for persisting user credentials
+      def initialize(client_id, scope, token_store = nil)
+        super(client_id, scope, token_store, nil)
+        @local_port = 8081
+      end
+
+      # Get credentials for the the user. May block to attempt authorization
+      # if no stored credentials are found locally.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials. Preference is to use
+      #  the email address of the google account.
+      # @yield [String] Authorization URL
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  User credentials
+      # @see {#request_authorization}
+      def get_credentials(user_id, &block)
+        credentials = super(user_id)
+        if credentials.nil?
+          credentials = request_authorization(user_id, &block)
+        end
+        credentials
+      end
+
+      # The default behavior for acquiring authorization launches the
+      # user's default browser along with running an embedded server
+      # on localhost to handle the callback. For cases where launching
+      # a browser is infeasible (e.g. terminal only) a block may be supplied
+      # instead. The block will be called with the authorization URL and is expected
+      # to return the authorization code after prompting the user.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @yield [String] Authorization URL
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  User credentials
+      def request_authorization(user_id, &block)
+        if block
+          base_url = OOB_URI
+          handler = Proc.new { |url| block.call(url) }
+        else
+          base_url = "http://localhost:#{@local_port}"
+          handler = Proc.new { |url| run_callback_server(url) }
+        end
+        auth_url = get_authorization_url(:login_hint => user_id, :base_url => base_url)
+        code = handler.call(auth_url)
+        get_and_store_credentials_from_code(:user_id => user_id, :code => code, :base_url => base_url)
+      end
+
+      private
+
+      RESPONSE_BODY = <<-HTML
+        <html>
+          <head>
+            <script>
+              function closeWindow() {
+                window.open('', '_self', '');
+                window.close();
+              }
+              setTimeout(closeWindow, 10);
+            </script>
+          </head>
+          <body>You may close this window.</body>
+        </html>
+      HTML
+
+      # Start an HTTP server to handle the authorization callback.
+      #
+      # @param [String] url
+      #  Authorization URL to launch browser for
+      def run_callback_server(url)
+        server = create_server(@local_port)
+        code = nil
+        begin
+          trap("INT") { server.shutdown }
+          proc = lambda do |req, res|
+            code = req.query['code']
+            res.status = WEBrick::HTTPStatus::RC_ACCEPTED
+            res.body = RESPONSE_BODY
+            server.stop
+          end
+          server.mount_proc '/', &proc
+          Launchy.open(url)
+          server.start
+        ensure
+          server.shutdown
+        end
+        code
+      end
+
+      def create_server(port)
+        WEBrick::HTTPServer.new(
+          :Port => port,
+          :BindAddress => "localhost",
+          :Logger => WEBrick::Log.new(STDOUT, 0),
+          :AccessLog => []
+        )
+      end
+
+    end
+
+  end
+end

--- a/lib/googleauth/rails/auth_callback_app.rb
+++ b/lib/googleauth/rails/auth_callback_app.rb
@@ -1,0 +1,82 @@
+# Copyright 2014, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rack/request'
+require 'googleauth/web_user_authorizer'
+
+module Google
+  module Auth
+    # Small Rack app which acts as the default callback handler for the app.
+    #
+    # To configure in Rails, add to routes.rb:
+    #
+    #     match '/oauth2callback', to: Google::Auth::Web::AuthCallbackApp, via: :all
+    #
+    # With Rackup, add to config.ru:
+    #
+    #     map '/oauth2callback' { run Google::Auth::Web::AuthCallbackApp }
+    #
+    # Or in a classic Sinatra app:
+    #
+    #     get('/oauth2callback') { Google::Auth::Web::AuthCallbackApp.call(env) }
+    #
+    # @see {Google::Auth::Web::WebUserAuthorizer}
+    class AuthCallbackApp
+      LOCATION_HEADER = 'Location'
+      REDIR_STATUS = 302
+      ERROR_STATUS = 500
+
+      # Handle a rack request. Simply stores the results the authorization
+      # in the session temporarily and redirects back to to the previously
+      # saved redirect URL. Credentials can be later retrieved by calling.
+      # {Google::Auth::Web::WebUserAuthorizer#get_credentials}
+      #
+      # See {Google::Auth::Web::WebUserAuthorizer#get_authorization_uri}
+      # for how to initiate authorization requests.
+      #
+      # @param [Hash] env
+      #  Rack environment
+      # @return [Array]
+      #  HTTP response
+      def self.call(env)
+        request = Rack::Request.new(env)
+        return_url = WebUserAuthorizer.handle_auth_callback_deferred(request)
+        if return_url
+          [REDIR_STATUS, { LOCATION_HEADER => return_url }, []]
+        else
+          [ERROR_STATUS, {}, ['No return URL is present in the request.']]
+        end
+      end
+
+      def call(env)
+        self.class.call(env)
+      end
+    end
+  end
+end

--- a/lib/googleauth/rails/controller_helpers.rb
+++ b/lib/googleauth/rails/controller_helpers.rb
@@ -1,0 +1,110 @@
+require 'rails'
+require 'googleauth/token_store'
+require 'googleauth/web_user_authorizer'
+
+module Google
+  module Auth
+
+    # Helpers for rails controllers to simplify the most common usage patterns.
+    #
+    # In the most basic form, authorization can be added by declaring a before_action
+    # filter for a controller:
+    #
+    #     before_action :require_google_credentials
+    #
+    # This assumes that:
+    # - The authorization scope required is configured via `config.googleauth.scope`
+    # - The unique ID of the user is available at `session[:user_id]`
+    #
+    # Upon passing the filter, the user credentials are available in the instance
+    # variable `@google_user_credentials` and can be used to access the corresponding
+    # APIs.
+    #
+    # The filter can be customized by supplying a block instead. This can be used
+    # to supply a different user ID or require a different scope depending on
+    # the controller. The following sample uses the Google API client  from Google Drive:
+    #
+    #     class FileController < ApplicationController
+    #       before_action do
+    #         require_google_credentials(user_id: current_user.email,
+    #                                    scope: 'https://www.googleapis.com/auth/drive')
+    #       end
+    #
+    #       def index
+    #         drive = Google::Apis::DriveV2::DriveService.new
+    #         drive.authorization = @google_user_credentials
+    #         @files = drive.list_files(q: "mimeType = 'application/pdf')
+    #       end
+    #     end
+    #
+    module ControllerHelpers
+
+      # Ensure that user credentials are available for the request.  Intended to be
+      # used as a filter on controllers, but can be called directly within a controller
+      # method as well.
+      #
+      # After calling, credentials are available via the `@google_user_credentials` instance
+      # variable on the controller.
+      #
+      # If no credentials available, the user will be redirected for authorization.
+      #
+      # @param [String] user_id
+      #  Unique user ID to load credentials for. Defaults to `session[:user_id]` if nil.
+      # @param [String] login_hint
+      #  Optional email address or google profile ID of the user to request authorization for.
+      # @param [Array<String>,String] scope
+      #  Scope to require authorization for. If specified, credentials will only be made
+      #  available if and only if they are authorized for the specified scope. If nil, uses
+      #  the default scope configured for the app.
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Credentials, if present
+      def require_google_credentials(options = {})
+        @google_user_credentials = google_user_credentials(options)
+        if @google_user_credentials.nil?
+          redirect_to_google_auth_url(options)
+        end
+        @google_user_credentials
+      end
+
+      # Retrieve user credentials.
+      #
+      # @param [String] user_id
+      #  Unique user ID to load credentials for. Defaults to `session[:user_id]` if nil.
+      # @param [String] scope
+      #  Scope to require authorization for. If specified, credentials will only be made
+      #  available if and only if they are authorized for the specified scope. If nil, no scope
+      #  check is performed and any available credentials are returned as is.
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Credentials, if present
+      def google_user_credentials(options = {})
+        user_id = options[:user_id] || session[:user_id]
+        google_user_authorizer.get_credentials(user_id, request, options[:scope])
+      end
+
+      # Redirects the user to request authorization.
+      #
+      # @param [String] login_hint
+      #  Optional email address or google profile ID of the user to request authorization for.
+      # @param [String] redirect_to
+      #  Optional URL to proceed to after authorization complete. Defaults to the current URL.
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request. Overrides the instance scopes if not nil.
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Credentials, if present
+      def redirect_to_google_auth_url(options = {})
+        url = google_user_authorizer.get_authorization_url(:login_hint => options[:login_hint],
+                                                           :request => request,
+                                                           :redirect_to => options[:redirect_to],
+                                                           :scope => options[:scope])
+        redirect_to url
+      end
+
+      # Retrieves the default authorizer
+      #
+      # @return [Google::Auth::WebUserAuthorizer]
+      def google_user_authorizer
+        Google::Auth::WebUserAuthorizer.default
+      end
+    end
+  end
+end

--- a/lib/googleauth/rails/railtie.rb
+++ b/lib/googleauth/rails/railtie.rb
@@ -1,0 +1,75 @@
+require 'rails'
+require 'googleauth/token_store'
+require 'googleauth/web_user_authorizer'
+require 'googleauth/rails/controller_helpers'
+
+module Google
+  module Auth
+
+    # Railtie for simplified integration with Rails. Exposes configuration via Rails config
+    # and performs initialiation on startup.
+    class Railtie < Rails::Railtie
+      config.googleauth = ActiveSupport::OrderedOptions.new
+      config.googleauth.token_store = :active_record
+      config.googleauth.client_secret_path = nil
+      config.googleauth.id = nil
+      config.googleauth.secret = nil
+      config.googleauth.scope = %w(email profile)
+      config.googleauth.callback_uri = '/oauth2callback'
+      config.googleauth.token_store_options = {}
+      config.googleauth.include_helpers = true
+
+      # Initialize authorizers based on config
+      config.after_initialize do
+        opts = config.googleauth
+        client_id = load_client_id
+        token_store = load_token_store
+        if client_id.nil?
+          Rails.logger.warn("Unable to configure googleauth library, no client secret available")
+        elsif token_store.nil?
+          Rails.logger.warn("Unable to configure googleauth library, no token store configured")
+        else
+          puts "opts.scope = #{opts.scope}"
+          Google::Auth::WebUserAuthorizer.default = Google::Auth::WebUserAuthorizer.new(
+              client_id,
+              opts.scope,
+              token_store,
+              opts.callback_uri)
+          if config.googleauth.include_helpers
+            ActionController::Base.send(:include, Google::Auth::ControllerHelpers)
+          end
+        end
+      end
+
+      # Load the client ID
+      def load_client_id
+        opts = config.googleauth
+        return Google::Auth::ClientId.new(opts.id, opts.secret) if opts.id
+        client_secret = config.googleauth.client_secret_path || File.join(Rails.root, 'config', 'client_secret.json')
+        return nil unless File.exists?(client_secret)
+        Rails.logger.info("Initializing client ID from #{client_secret}")
+        Google::Auth::ClientId.from_file(client_secret)
+      end
+
+      # Initialize the token store
+      def load_token_store
+        token_store = config.googleauth.token_store
+        case token_store
+        when Google::Auth::TokenStore
+          token_store
+        when :active_record
+          require 'googleauth/stores/active_record_token_store'
+          Google::Auth::Stores::ActiveRecordTokenStore.new(config.googleauth.token_store_options)
+        when :redis
+          require 'googleauth/stores/redis_token_store'
+          Google::Auth::Stores::RedisTokenStore.new(config.googleauth.token_store_options)
+        when :file
+          require 'googleauth/stores/file_token_store'
+          Google::Auth::Stores::FileTokenStore.new(config.googleauth.token_store_options)
+        else
+          fail "Unsupported token store: #{token_store}"
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/scope_util.rb
+++ b/lib/googleauth/scope_util.rb
@@ -27,59 +27,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-spec_dir = File.expand_path(File.dirname(__FILE__))
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
+require 'googleauth/signet'
+require 'googleauth/credentials_loader'
+require 'multi_json'
 
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
-$LOAD_PATH.uniq!
+module Google
+  module Auth
+    module ScopeUtil
+      
+      ALIASES = {
+        'email' => 'https://www.googleapis.com/auth/userinfo.email',
+        'profile' => 'https://www.googleapis.com/auth/userinfo.profile',
+        'openid' => 'https://www.googleapis.com/auth/plus.me'
+      }     
+       
+      def self.normalize(scope)
+        list = self.as_array(scope)
+        list.map {|item| ALIASES[item] || item }        
+      end
 
-# set up coverage
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start
-
-require 'faraday'
-require 'rspec'
-require 'logging'
-require 'rspec/logging_helper'
-require 'webmock/rspec'
-
-
-# Allow Faraday to support test stubs
-Faraday::Adapter.load_middleware(:test)
-
-# Configure RSpec to capture log messages for each test. The output from the
-# logs will be stored in the @log_output variable. It is a StringIO instance.
-RSpec.configure do |config|
-  include RSpec::LoggingHelper
-  config.capture_log_messages
-  config.include WebMock::API
-end
-
-
-module TestHelpers
-  include WebMock::API
-  include WebMock::Matchers
-end
-
-class DummyTokenStore
-  def initialize
-    @tokens = Hash.new
-  end
-
-  def load(id)
-    @tokens[id]
-  end
-
-  def store(id, token)
-    @tokens[id] = token
-  end
-
-  def delete(id)
-    @tokens.delete(id)
+      def self.as_array(scope)
+        case scope
+        when Array
+          scope
+        when String
+          scope.split(' ')
+        else
+          fail "Invalid scope value. Must be string or array"
+        end
+      end
+    end
   end
 end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -58,6 +58,25 @@ module Signet
       def updater_proc
         lambda(&method(:apply))
       end
+      
+      def on_refresh(&block)
+        @refresh_listeners ||= []
+        @refresh_listeners << block
+      end
+      
+      alias_method :orig_fetch_access_token!, :fetch_access_token!
+      def fetch_access_token!(options)
+        info = orig_fetch_access_token!(options)
+        notify_refresh_listeners
+        info
+      end
+      
+      def notify_refresh_listeners
+        listeners = @refresh_listeners || []
+        listeners.each do |block|
+          block.call(self)
+        end
+      end          
     end
   end
 end

--- a/lib/googleauth/stores/file_token_store.rb
+++ b/lib/googleauth/stores/file_token_store.rb
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2014, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,59 +27,39 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-spec_dir = File.expand_path(File.dirname(__FILE__))
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
+require 'yaml/store'
+require 'googleauth/token_store'
 
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
-$LOAD_PATH.uniq!
-
-# set up coverage
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start
-
-require 'faraday'
-require 'rspec'
-require 'logging'
-require 'rspec/logging_helper'
-require 'webmock/rspec'
-
-
-# Allow Faraday to support test stubs
-Faraday::Adapter.load_middleware(:test)
-
-# Configure RSpec to capture log messages for each test. The output from the
-# logs will be stored in the @log_output variable. It is a StringIO instance.
-RSpec.configure do |config|
-  include RSpec::LoggingHelper
-  config.capture_log_messages
-  config.include WebMock::API
-end
-
-
-module TestHelpers
-  include WebMock::API
-  include WebMock::Matchers
-end
-
-class DummyTokenStore
-  def initialize
-    @tokens = Hash.new
-  end
-
-  def load(id)
-    @tokens[id]
-  end
-
-  def store(id, token)
-    @tokens[id] = token
-  end
-
-  def delete(id)
-    @tokens.delete(id)
+module Google
+  module Auth
+    module Stores
+          
+      # Implementation of user token storage backed by a local YAML file      
+      class FileTokenStore < Google::Auth::TokenStore        
+        # Create a new store with the supplied file.
+        #
+        # @param [String, File] file
+        #  Path to storage file
+        def initialize(options = {})
+          path = options[:file]
+          @store = YAML::Store.new(path)
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#load)
+        def load(id)
+          @store.transaction { @store[id] }
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#store)
+        def store(id, token)
+          @store.transaction { @store[id] = token }
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#delete)
+        def delete(id)
+          @store.transaction { @store.delete(id) }
+        end
+      end
+    end
   end
 end

--- a/lib/googleauth/stores/redis_token_store.rb
+++ b/lib/googleauth/stores/redis_token_store.rb
@@ -1,0 +1,94 @@
+# Copyright 2014, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'redis'
+require 'googleauth/token_store'
+
+module Google
+  module Auth
+    module Stores
+      # Implementation of user token storage backed by Redis. Tokens
+      # are stored as JSON using the supplied key, prefixed with
+      # `g-user-token:`
+      class RedisTokenStore < Google::Auth::TokenStore
+        DEFAULT_KEY_PREFIX = 'g-user-token:'
+        
+        # Create a new store with the supplied redis client. 
+        #
+        # @param [::Redis, String] redis
+        #  Initialized redis client to connect to.
+        # @param [String] prefix
+        #  Prefix for keys in redis. Defaults to 'g-user-token:'
+        # @note If no redis instance is provided, a new one is created and the options passed through. You may
+        #  include any other keys accepted by `Redis.new`
+        def initialize(options = {})
+          redis = options.delete(:redis)
+          prefix = options.delete(:prefix)
+          case redis
+          when Redis
+            @redis = redis
+          else
+            @redis = Redis.new(options)
+          end
+          @prefix = prefix || DEFAULT_KEY_PREFIX
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#load)
+        def load(id)
+          key = key_for(id)
+          @redis.get(key)
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#store)
+        def store(id, token)
+          key = key_for(id)
+          @redis.set(key, token)
+        end
+        
+        # (see Google::Auth::Stores::TokenStore#delete)
+        def delete(id)
+          key = key_for(id)
+          @redis.del(key)
+        end
+        
+        private
+        
+        # Generate a redis key from a token ID
+        #
+        # @param [String] id
+        #  ID of the token
+        # @return [String]
+        #  Redis key
+        def key_for(id)
+          @prefix + id
+        end
+      end
+    end
+  end
+end

--- a/lib/googleauth/token_store.rb
+++ b/lib/googleauth/token_store.rb
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2014, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,59 +27,44 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-spec_dir = File.expand_path(File.dirname(__FILE__))
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
-
-$LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
-$LOAD_PATH.uniq!
-
-# set up coverage
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start
-
-require 'faraday'
-require 'rspec'
-require 'logging'
-require 'rspec/logging_helper'
-require 'webmock/rspec'
-
-
-# Allow Faraday to support test stubs
-Faraday::Adapter.load_middleware(:test)
-
-# Configure RSpec to capture log messages for each test. The output from the
-# logs will be stored in the @log_output variable. It is a StringIO instance.
-RSpec.configure do |config|
-  include RSpec::LoggingHelper
-  config.capture_log_messages
-  config.include WebMock::API
-end
-
-
-module TestHelpers
-  include WebMock::API
-  include WebMock::Matchers
-end
-
-class DummyTokenStore
-  def initialize
-    @tokens = Hash.new
-  end
-
-  def load(id)
-    @tokens[id]
-  end
-
-  def store(id, token)
-    @tokens[id] = token
-  end
-
-  def delete(id)
-    @tokens.delete(id)
+module Google
+  module Auth
+    # Interface definition for token stores. It is not required that
+    # implementations inherit from this class. It is provided for documentation
+    # purposes to illustrate the API contract.
+    class TokenStore
+      
+      class << self
+        attr_accessor :default
+      end
+      
+      # Load the token data from storage for the given ID.
+      #
+      # @param [String] id
+      #  ID of token data to load.
+      # @return [String]
+      #  The loaded token data.
+      def load(id)
+        fail "Not implemented"
+      end
+      
+      # Put the token data into storage for the given ID.
+      #
+      # @param [String] id
+      #  ID of token data to store.
+      # @param [String] token
+      #  The token data to store.
+      def store(id, token)
+        fail "Not implemented"
+      end
+      
+      # Remove the token data from storage for the given ID.
+      #
+      # @param [String] id
+      #  ID of the token data to delete
+      def delete(id)
+        fail "Not implemented"
+      end
+    end
   end
 end

--- a/lib/googleauth/user_authorizer.rb
+++ b/lib/googleauth/user_authorizer.rb
@@ -1,0 +1,250 @@
+# Copyright 2014, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'uri'
+require 'multi_json'
+require 'googleauth/signet'
+require 'googleauth/user_refresh'
+
+module Google
+  module Auth
+
+    # Handles an interactive 3-Legged-OAuth2 (3LO) user consent authorization.
+    #
+    # Example usage for a simple command line app:
+    #
+    #     credentials = authorizer.get_credentials(user_id)
+    #     if credentials.nil?
+    #       url = authorizer.get_redirect_uri(user_id, nil, 'urn:ietf:wg:oauth:2.0:oob')
+    #       puts "Open the following URL in the browser and enter the resulting code after authorization"
+    #       puts url
+    #       code = gets
+    #       credentials = authorizer.get_and_store_credentials_from_code(user_id, code)
+    #     end
+    #     # Credentials ready to use, call APIs
+    #     ...
+    #
+    # Web applications should use {Google::Auth::Web::WebUserAuthorizer}.
+    class UserAuthorizer
+
+      # Initialize the authorizer
+      #
+      # @param [Google::Auth::ClientID] client_id
+      #  Configured ID & secret for this application
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request
+      # @param [Google::Auth::Stores::TokenStore] token_store
+      #  Backing storage for persisting user credentials
+      # @param [String] callback_uri
+      #  URL (either absolute or relative) of the auth callback. Defaults to '/oauth2callback'
+      def initialize(client_id, scope, token_store, callback_uri = nil)
+        fail "Client id can not be nil." if client_id.nil?
+        fail "Scope can not be nil." if scope.nil?
+
+        @client_id = client_id
+        @scope = Array(scope)
+        @token_store = token_store
+        @callback_uri = callback_uri || '/oauth2callback'
+      end
+
+      # Build the URL for requesting authorization.
+      #
+      # @param [String] login_hint
+      #  Login hint if need to authorize a specific account. Should be a user's email address
+      #  or unique profile ID.
+      # @param [String] state
+      #  Opaque state value to be returned to the oauth callback.
+      # @param [String] base_url
+      #  Absolute URL to resolve the configured callback uri against. Required if the configured
+      #  callback uri is a relative.
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request. Overrides the instance scopes if not nil.
+      # @return [String]
+      #  Authorization url
+      def get_authorization_url(options = {})
+        scope = options[:scope] || @scope
+        credentials = UserRefreshCredentials.new(client_id: @client_id.id,
+                                                 client_secret: @client_id.secret,
+                                                 scope: scope)
+        url = credentials.authorization_uri(access_type: 'offline',
+                                      redirect_uri: redirect_uri_for(options[:base_url]),
+                                      approval_prompt: 'force',
+                                      state: options[:state],
+                                      include_granted_scopes: true,
+                                      login_hint: options[:login_hint])
+        url.to_s
+      end
+
+      # Fetch stored credentials for the user.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [Array<String>, String] scope
+      #  If specified, only returns credentials that have all the requested scopes
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Stored credentials, nil if none present
+      def get_credentials(user_id, scope = nil)
+        fail "User ID can not be nil." if user_id.nil?
+        fail "Can not call method if token store is nil" if @token_store.nil?
+
+        scope ||= @scope
+        saved_token = @token_store.load(user_id)
+        return nil if saved_token.nil?
+        data = MultiJson.load(saved_token)
+
+        if data.fetch('client_id', @client_id.id) != @client_id.id
+          fail "Token client ID of #{data['client_id']} does not match configured client id #{@client_id.id}"
+        end
+
+        credentials = UserRefreshCredentials.new(client_id: @client_id.id,
+                                   client_secret: @client_id.secret,
+                                   scope: data['scope'] || @scope,
+                                   access_token: data['access_token'],
+                                   refresh_token: data['refresh_token'],
+                                   expires_at: data.fetch('expiration_time_millis', 0) / 1000)
+        if credentials.includes_scope?(scope)
+          monitor_credentials(user_id, credentials)
+          return credentials
+        end
+        nil
+      end
+
+      # Exchanges an authorization code returned in the oauth callback
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [String] code
+      #  The authorization code from the OAuth callback
+      # @param [String, Array<String>] scope
+      #  Authorization scope requested. Overrides the instance scopes if not nil.
+      # @param [String] base_url
+      #  Absolute URL to resolve the configured callback uri against. Required if the configured
+      #  callback uri is a relative.
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Credentials if exchange is successful
+      def get_credentials_from_code(options = {})
+        user_id = options[:user_id]
+        code = options[:code]
+        scope = options[:scope] || @scope
+        base_url = options[:base_url]
+        credentials = UserRefreshCredentials.new(client_id: @client_id.id,
+                                                 client_secret: @client_id.secret,
+                                                 redirect_uri: redirect_uri_for(base_url),
+                                                 scope: scope)
+        credentials.code = code
+        credentials.fetch_access_token!({})
+        monitor_credentials(user_id, credentials)
+      end
+
+      # Exchanges an authorization code returned in the oauth callback. Additionally, stores
+      # the resulting credentials in the token store if the exchange is successful.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [String] code
+      #  The authorization code from the OAuth callback
+      # @param [String, Array<String>] scope
+      #  Authorization scope requested. Overrides the instance scopes if not nil.
+      # @param [String] base_url
+      #  Absolute URL to resolve the configured callback uri against. Required if the configured
+      #  callback uri is a relative.
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Credentials if exchange is successful
+      def get_and_store_credentials_from_code(options = {})
+        credentials = get_credentials_from_code(options)
+        monitor_credentials(options[:user_id], credentials)
+        store_credentials(options[:user_id], credentials)
+      end
+
+      # Revokes a user's credentials. This both revokes the actual grant as well as
+      # removes the token from the token store.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      def revoke_authorization(user_id)
+        credentials = get_credentials(user_id)
+        if credentials
+          begin
+            @token_store.delete(user_id)
+          ensure
+            credentials.revoke!
+          end
+        end
+        nil
+      end
+
+      # Store credentials for a user. Generally not required to be called directly,
+      # but may be used to migrate tokens from one store to another.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [Google::Auth::UserRefreshCredentials] credentials
+      #  Credentials to store.
+      def store_credentials(user_id, credentials)
+        json = MultiJson.dump({
+          client_id: credentials.client_id,
+          access_token: credentials.access_token,
+          refresh_token: credentials.refresh_token,
+          scope: credentials.scope,
+          expiration_time_millis: (credentials.expires_at.to_i) * 1000
+        })
+        @token_store.store(user_id, json)
+        credentials
+      end
+
+      private
+
+      # Begin watching a credential for refreshes so the access token can be
+      # saved.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [Google::Auth::UserRefreshCredentials] credentials
+      #  Credentials to store.
+      def monitor_credentials(user_id, credentials)
+        credentials.on_refresh do |credentials|
+          store_credentials(user_id, credentials)
+        end
+        credentials
+      end
+
+      # Resolve the redirect uri against a base.
+      #
+      # @param [String] base_url
+      #  Absolute URL to resolve the callback against if necessary.
+      # @return [String]
+      #  Redirect URI
+      def redirect_uri_for(base_url)
+        return @callback_uri unless URI(@callback_uri).scheme.nil?
+        fail "Absolute base url required for relative callback url #{@callback_uri}." if base_url.nil? || URI(base_url).scheme.nil?
+        URI.join(base_url, @callback_uri).to_s
+      end
+    end
+  end
+end

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.4.2'
+    VERSION = '0.5'
   end
 end

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -1,0 +1,218 @@
+# Copyright 2014, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'multi_json'
+require 'googleauth/signet'
+require 'googleauth/user_authorizer'
+require 'googleauth/user_refresh'
+require 'securerandom'
+
+module Google
+  module Auth
+    # Varation on {Google::Auth::UserAuthorizer} adapted for Rack based
+    # web applications.
+    #
+    # Example usage:
+    #
+    #     get('/') do
+    #       user_id = request.session['user_email']
+    #       credentials = authorizer.get_credentials(user_id, request)
+    #       if credentials.nil?
+    #         redirect authorizer.get_redirect_uri(user_id, request)
+    #       end
+    #       # Credentials are valid, can call APIs
+    #       ...
+    #    end
+    #
+    #    get('/oauth2callback') do
+    #       user_id = request.session['user_email']
+    #      _, return_uri = authorizer.handle_auth_callback(user_id, request)
+    #      redirect return_uri
+    #    end
+    #
+    # Instead of implementing the callback directly, applications are encouraged to
+    # use {Google::Auth::Web::AuthCallbackApp} instead.
+    #
+    # @see {Google::Auth::Web::AuthCallbackApp}
+    # @note Requires sessions are enabled
+    class WebUserAuthorizer < Google::Auth::UserAuthorizer
+      STATE_PARAM = 'state'
+      AUTH_CODE_KEY = 'code'
+      ERROR_CODE_KEY = 'error'
+      SESSION_ID_KEY = 'session_id'
+      CALLBACK_STATE_KEY = 'g-auth-callback'
+      CURRENT_URI_KEY = 'current_uri'
+      XSRF_KEY = 'g-xsrf-token'
+      SCOPE_KEY = 'scope'
+
+      class << self
+        attr_accessor :default
+      end
+
+      # Handle the result of the oauth callback. This version defers the exchange
+      # of the code by temporarily stashing the results in the user's session. This
+      # allows apps to use the generic {Google::Auth::Web::AuthCallbackApp} handler
+      # for the callback without any additional customization.
+      #
+      # Apps that wish to handle the callback directly should use {#handle_auth_callback}
+      # instead.
+      #
+      # @param [Rack::Request] request
+      #  Current request
+      def self.handle_auth_callback_deferred(request)
+        callback_state, redirect_uri = self.extract_callback_state(request)
+        request.session[CALLBACK_STATE_KEY] = MultiJson.dump(callback_state)
+        return redirect_uri
+      end
+
+      # Initialize the authorizer
+      #
+      # @param [Google::Auth::ClientID] client_id
+      #  Configured ID & secret for this application
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request
+      # @param [Google::Auth::Stores::TokenStore] token_store
+      #  Backing storage for persisting user credentials
+      # @param [String] callback_uri
+      #  URL (either absolute or relative) of the auth callback. Defaults to '/oauth2callback'
+      def initialize(client_id, scope, token_store, callback_uri = nil)
+        super(client_id, scope, token_store, callback_uri)
+      end
+
+
+      # Handle the result of the oauth callback. Exchanges the authorization code from the
+      # request and persists to storage.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [Rack::Request] request
+      #  Current request
+      # @return (Google::Auth::UserRefreshCredentials, String)
+      #  credentials & next URL to redirect to
+      def handle_auth_callback(user_id, request)
+        callback_state, redirect_uri = WebUserAuthorizer.extract_callback_state(request)
+        WebUserAuthorizer.validate_callback_state(callback_state, request)
+        credentials = get_and_store_credentials_from_code(:user_id => user_id,
+                                                          :code => callback_state[AUTH_CODE_KEY],
+                                                          :scope => callback_state[SCOPE_KEY],
+                                                          :base_url => request.url)
+        return credentials, redirect_uri
+      end
+
+      # Build the URL for requesting authorization.
+      #
+      # @param [String] login_hint
+      #  Login hint if need to authorize a specific account. Should be a user's email address
+      #  or unique profile ID.
+      # @param [Rack::Request] request
+      #  Current request
+      # @param [String] redirect_to
+      #  Optional URL to proceed to after authorization complete. Defaults to the current URL.
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request. Overrides the instance scopes if not nil.
+      # @return [String]
+      #  Authorization url
+      def get_authorization_url(options = {})
+        options = options.dup
+        request = options[:request]
+        fail "Request is required." if request.nil?
+        fail "Sessions must be enabled" if request.session.nil?
+
+        redirect_to = options[:redirect_to] || request.url
+        request.session[XSRF_KEY] = SecureRandom.base64
+        options[:state] = MultiJson.dump({
+          SESSION_ID_KEY => request.session[XSRF_KEY],
+          CURRENT_URI_KEY => redirect_to
+        })
+        options[:base_url] = request.url
+        super(options)
+      end
+
+
+      # Fetch stored credentials for the user.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @param [Rack::Request] request
+      #  Current request
+      # @param [Array<String>, String] scope
+      #  If specified, only returns credentials that have all the requested scopes
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  Stored credentials, nil if none present
+      # @raise [Signet::AuthorizationError]
+      #  May raise an error if an authorization code is present in the session
+      #  and exchange of the code fails
+      def get_credentials(user_id, request, scope = nil)
+        if request.session.has_key?(CALLBACK_STATE_KEY)
+          # Note - in theory, no need to check required scope as this is expected
+          # to be called immediately after a return from authorization
+          state_json = request.session.delete(CALLBACK_STATE_KEY)
+          callback_state = MultiJson.load(state_json)
+          WebUserAuthorizer.validate_callback_state(callback_state, request)
+          get_and_store_credentials_from_code(:user_id => user_id,
+                                              :code => callback_state[AUTH_CODE_KEY],
+                                              :scope => callback_state[SCOPE_KEY],
+                                              :base_url => request.url)
+        else
+          super(user_id, scope)
+        end
+      end
+
+      private
+
+      def self.extract_callback_state(request)
+        state = MultiJson.load(request[STATE_PARAM] || '{}')
+        redirect_uri = state[CURRENT_URI_KEY]
+        callback_state = {
+          AUTH_CODE_KEY => request[AUTH_CODE_KEY],
+          ERROR_CODE_KEY =>  request[ERROR_CODE_KEY],
+          SESSION_ID_KEY => state[SESSION_ID_KEY],
+          SCOPE_KEY => request[SCOPE_KEY]
+        }
+        return callback_state, redirect_uri
+      end
+
+      # Verifies the results of an authorization callback
+      #
+      # @param [Hash] state
+      #  Callback state
+      # @option state [String] AUTH_CODE_KEY
+      #  The authorization code
+      # @option state [String] ERROR_CODE_KEY
+      #  Error message if failed
+      # @param [Rack::Request] request
+      #  Current request
+      def self.validate_callback_state(state, request)
+        fail Signet::AuthorizationError, "Missing authorization code in request" if state[AUTH_CODE_KEY].nil?
+        fail Signet::AuthorizationError, "Authorization error: #{state[ERROR_CODE_KEY]}" if state[ERROR_CODE_KEY]
+        fail Signet::AuthorizationError, "State token does not match expected value" if request.session[XSRF_KEY] != state[SESSION_ID_KEY]
+      end
+    end
+  end
+end

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -56,17 +56,29 @@ shared_examples 'apply/apply! are OK' do
   # @make_auth_stubs, which should stub out the expected http behaviour of the
   # auth client
   describe '#fetch_access_token' do
-    it 'should set access_token to the fetched value' do
-      token = '1/abcdef1234567890'
+    let(:token) { '1/abcdef1234567890' }
+    let(:stubs) do
       stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
+    end
+    let(:connection) do
+      Faraday.new do |b|
         b.adapter(:test, stubs)
       end
-
-      @client.fetch_access_token!(connection: c)
+    end
+    
+    it 'should set access_token to the fetched value' do
+      @client.fetch_access_token!(connection: connection)
       expect(@client.access_token).to eq(token)
       stubs.verify_stubbed_calls
     end
+    
+    it 'should notify refresh listeners after updating' do
+      expect do |b| 
+        @client.on_refresh(&b)
+        @client.fetch_access_token!(connection: connection)
+      end.to yield_with_args(have_attributes(access_token: '1/abcdef1234567890'))
+      stubs.verify_stubbed_calls
+    end      
   end
 
   describe '#apply!' do

--- a/spec/googleauth/client_id_spec.rb
+++ b/spec/googleauth/client_id_spec.rb
@@ -1,0 +1,139 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
+$LOAD_PATH.unshift(spec_dir)
+$LOAD_PATH.uniq!
+
+require 'fakefs/safe'
+require 'googleauth'
+
+describe Google::Auth::ClientId do
+
+  shared_examples 'it has a valid config' do
+    it 'should include a valid id' do
+      expect(client_id.id).to eql 'abc@example.com'
+    end
+
+    it 'should include a valid secret' do
+      expect(client_id.secret).to eql 'notasecret'
+    end
+  end
+
+  shared_examples 'it can successfully load client_id' do
+    context 'loaded from hash' do
+      let(:client_id) { Google::Auth::ClientId.from_hash(config) }
+
+      it_behaves_like 'it has a valid config'
+    end
+
+    context 'loaded from file' do
+      FILE_PATH = '/client_secrets.json'
+
+      let(:client_id) do
+        FakeFS do
+          content = MultiJson.dump(config)
+          File.write(FILE_PATH, content)
+          Google::Auth::ClientId.from_file(FILE_PATH)
+        end
+      end
+
+      it_behaves_like 'it has a valid config'
+    end
+  end
+
+  describe 'with web config' do
+    let(:config) do
+      {
+        'web' => {
+          'client_id' => 'abc@example.com',
+          'client_secret' => 'notasecret'
+        }
+      }
+    end
+    it_behaves_like 'it can successfully load client_id'
+  end
+
+  describe 'with installed app config' do
+    let(:config) do
+      {
+        'installed' => {
+          'client_id' => 'abc@example.com',
+          'client_secret' => 'notasecret'
+        }
+      }
+    end
+    it_behaves_like 'it can successfully load client_id'
+  end
+
+  context 'with missing top level property' do
+    let(:config) do
+      {
+        'notvalid' => {
+          'client_id' => 'abc@example.com',
+          'client_secret' => 'notasecret'
+        }
+      }
+    end
+
+    it 'should raise error' do
+      expect { Google::Auth::ClientId.from_hash(config) }.to raise_error(/Expected top level property/)
+    end
+
+  end
+
+  context 'with missing client id' do
+    let(:config) do
+      {
+        'web' => {
+          'client_secret' => 'notasecret'
+        }
+      }
+    end
+
+    it 'should raise error' do
+      expect { Google::Auth::ClientId.from_hash(config) }.to raise_error(/Client id can not be nil/)
+    end
+  end
+
+  context 'with missing client secret' do
+    let(:config) do
+      {
+        'web' => {
+          'client_id' => 'abc@example.com',
+        }
+      }
+    end
+
+    it 'should raise error' do
+      expect { Google::Auth::ClientId.from_hash(config) }.to raise_error(/Client secret can not be nil/)
+    end
+  end
+
+end

--- a/spec/googleauth/installed_app_user_authorizer_spec.rb
+++ b/spec/googleauth/installed_app_user_authorizer_spec.rb
@@ -1,0 +1,125 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
+$LOAD_PATH.unshift(spec_dir)
+$LOAD_PATH.uniq!
+
+require 'googleauth'
+require 'googleauth/user_authorizer'
+require 'uri'
+require 'multi_json'
+require 'spec_helper'
+
+
+
+describe Google::Auth::InstalledAppUserAuthorizer do
+  include TestHelpers
+
+  let(:client_id) { Google::Auth::ClientId.new('testclient', 'notasecret') }
+  let(:scope) { ['email', 'profile'] }
+  let(:token_store) { DummyTokenStore.new }
+  let(:token_json) do
+    MultiJson.dump('access_token' => '1/abc123',
+                   'token_type' => 'Bearer',
+                   'expires_in' => 3600)
+  end
+
+  before(:example) do
+    token_store.store('user2@example.com', token_json)
+  end
+
+  before(:example) do
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').to_return(
+      :body => token_json, :status => 200, :headers => { 'Content-Type' => 'application/json' })
+  end
+
+  let(:authorizer) do
+    Google::Auth::InstalledAppUserAuthorizer.new(client_id, scope, token_store)
+  end
+
+  context 'when invoked with callback' do
+    context 'with no saved credentials' do
+      it 'should prompt for authorization' do
+        expect do |b|
+          authorizer.get_credentials('user@example.com') do |url|
+            b.to_proc.call(url)
+            'code'
+          end
+        end.to yield_with_args(/https:\/\/accounts.google.com\/.*/)
+      end
+
+      it 'should return valid credentials' do
+        credentials = authorizer.get_credentials('user@example.com') do |url|
+          'code'
+        end
+        expect(credentials).to be_instance_of(Google::Auth::UserRefreshCredentials)
+      end
+    end
+  end
+
+  context 'when invoked without callback' do
+    context 'with no saved credentials' do
+      let(:server) do
+        double("webrick", :start => nil, :stop => nil, :shutdown => nil)
+      end
+
+      before(:example) do
+        allow(authorizer).to receive(:create_server).and_return(server)
+        expect(server).to receive(:mount_proc) do |url, &proc|
+          @proc = proc
+        end
+        expect(server).to receive(:start) do
+          request = double('request', :query => {'code' => 'authcode'})
+          response = double('response')
+          expect(response).to receive(:status=).with(202)
+          expect(response).to receive(:body=).with(String)
+          @proc.call(request, response)
+        end
+      end
+
+      let(:credentials) { authorizer.get_credentials('user@example.com') }
+
+      it 'should prompt for authorization' do
+        expect(Launchy).to receive(:open).with(/https:\/\/accounts.google.com\/.*/)
+        credentials
+      end
+
+      it 'should return valid credentials' do
+        expect(Launchy).to receive(:open).with(/https:\/\/accounts.google.com\/.*/)
+        expect(credentials).to be_instance_of(Google::Auth::UserRefreshCredentials)
+      end
+    end
+
+    it 'should return saved credentials' do
+      credentials = authorizer.get_credentials('user2@example.com')
+      expect(credentials).to be_instance_of(Google::Auth::UserRefreshCredentials)
+    end
+  end
+end

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -121,7 +121,7 @@ describe Google::Auth::ServiceAccountCredentials do
 
   before(:example) do
     @key = OpenSSL::PKey::RSA.new(2048)
-    @client = ServiceAccountCredentials.new(
+    @client = ServiceAccountCredentials.make_creds(
       json_key_io: StringIO.new(cred_json_text),
       scope: 'https://www.googleapis.com/auth/userinfo.profile'
     )
@@ -276,7 +276,7 @@ describe Google::Auth::ServiceAccountJwtHeaderCredentials do
 
   before(:example) do
     @key = OpenSSL::PKey::RSA.new(2048)
-    @client = clz.new(json_key_io: StringIO.new(cred_json_text))
+    @client = clz.make_creds(json_key_io: StringIO.new(cred_json_text))
   end
 
   def cred_json_text

--- a/spec/googleauth/stores/active_record_token_store_spec.rb
+++ b/spec/googleauth/stores/active_record_token_store_spec.rb
@@ -27,59 +27,42 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-spec_dir = File.expand_path(File.dirname(__FILE__))
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
-
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
 $LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.uniq!
 
-# set up coverage
-require 'simplecov'
-require 'coveralls'
+require 'googleauth'
+require 'googleauth/stores/active_record_token_store'
+require 'spec_helper'
+require 'googleauth/stores/store_examples'
+require 'active_record'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start
-
-require 'faraday'
-require 'rspec'
-require 'logging'
-require 'rspec/logging_helper'
-require 'webmock/rspec'
-
-
-# Allow Faraday to support test stubs
-Faraday::Adapter.load_middleware(:test)
-
-# Configure RSpec to capture log messages for each test. The output from the
-# logs will be stored in the @log_output variable. It is a StringIO instance.
-RSpec.configure do |config|
-  include RSpec::LoggingHelper
-  config.capture_log_messages
-  config.include WebMock::API
-end
-
-
-module TestHelpers
-  include WebMock::API
-  include WebMock::Matchers
-end
-
-class DummyTokenStore
-  def initialize
-    @tokens = Hash.new
-  end
-
-  def load(id)
-    @tokens[id]
-  end
-
-  def store(id, token)
-    @tokens[id] = token
-  end
-
-  def delete(id)
-    @tokens.delete(id)
+module FakeFS
+  class File
+    # FakeFS doesn't implement. And since we don't need to actually lock, just stub out...
+    def flock(*)
+    end
   end
 end
+
+describe Google::Auth::Stores::ActiveRecordTokenStore do
+  # Set up an in-memory DB for testing
+  before(:context) do
+    ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+    ActiveRecord::Schema.define do
+      self.verbose = false
+      create_table :google_auth_tokens do |t|
+        t.string :user_id
+        t.string :token
+      end
+      add_index :google_auth_tokens, :user_id
+    end
+  end
+  
+  let(:store) do
+    Google::Auth::Stores::ActiveRecordTokenStore.new
+  end
+    
+  it_behaves_like 'token store' 
+end
+

--- a/spec/googleauth/stores/redis_token_store_spec.rb
+++ b/spec/googleauth/stores/redis_token_store_spec.rb
@@ -27,59 +27,26 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-spec_dir = File.expand_path(File.dirname(__FILE__))
-root_dir = File.expand_path(File.join(spec_dir, '..'))
-lib_dir = File.expand_path(File.join(root_dir, 'lib'))
-
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
 $LOAD_PATH.unshift(spec_dir)
-$LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.uniq!
 
-# set up coverage
-require 'simplecov'
-require 'coveralls'
+require 'googleauth'
+require 'googleauth/stores/redis_token_store'
+require 'spec_helper'
+require 'fakeredis/rspec'
+require 'googleauth/stores/store_examples'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start
-
-require 'faraday'
-require 'rspec'
-require 'logging'
-require 'rspec/logging_helper'
-require 'webmock/rspec'
-
-
-# Allow Faraday to support test stubs
-Faraday::Adapter.load_middleware(:test)
-
-# Configure RSpec to capture log messages for each test. The output from the
-# logs will be stored in the @log_output variable. It is a StringIO instance.
-RSpec.configure do |config|
-  include RSpec::LoggingHelper
-  config.capture_log_messages
-  config.include WebMock::API
+describe Google::Auth::Stores::RedisTokenStore do
+  
+  let(:redis) do 
+    Redis.new
+  end
+  
+  let(:store) do
+    Google::Auth::Stores::RedisTokenStore.new(:redis => redis)
+  end
+  
+  it_behaves_like 'token store'      
 end
 
-
-module TestHelpers
-  include WebMock::API
-  include WebMock::Matchers
-end
-
-class DummyTokenStore
-  def initialize
-    @tokens = Hash.new
-  end
-
-  def load(id)
-    @tokens[id]
-  end
-
-  def store(id, token)
-    @tokens[id] = token
-  end
-
-  def delete(id)
-    @tokens.delete(id)
-  end
-end

--- a/spec/googleauth/user_authorizer_spec.rb
+++ b/spec/googleauth/user_authorizer_spec.rb
@@ -1,0 +1,300 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
+$LOAD_PATH.unshift(spec_dir)
+$LOAD_PATH.uniq!
+
+require 'googleauth'
+require 'googleauth/user_authorizer'
+require 'uri'
+require 'multi_json'
+require 'spec_helper'
+
+describe Google::Auth::UserAuthorizer do
+  include TestHelpers
+
+  let(:client_id) { Google::Auth::ClientId.new('testclient', 'notasecret') }
+  let(:scope) { ['email', 'profile'] }
+  let(:token_store) { DummyTokenStore.new }
+  let(:callback_uri) { 'https://www.example.com/oauth/callback' }
+  let(:authorizer) do
+    Google::Auth::UserAuthorizer.new(client_id, scope, token_store, callback_uri)
+  end
+
+  shared_examples 'valid authorization url' do
+    it 'should have a valid base URI' do
+      expect(uri).to match /https:\/\/accounts.google.com\/o\/oauth2\/auth/
+    end
+
+    it 'should request offline access' do
+      expect(URI(uri).query).to match /access_type=offline/
+    end
+
+    it 'should request response type code' do
+      expect(URI(uri).query).to match /response_type=code/
+    end
+
+    it 'should force approval' do
+      expect(URI(uri).query).to match /approval_prompt=force/
+    end
+
+    it 'should include granted scopes' do
+      expect(URI(uri).query).to match /include_granted_scopes=true/
+    end
+
+    it 'should include the correct client id' do
+      expect(URI(uri).query).to match /client_id=testclient/
+    end
+
+    it 'should not include a client secret' do
+      expect(URI(uri).query).to_not match /client_secret/
+    end
+
+    it 'should include the callback uri' do
+      expect(URI(uri).query).to match /redirect_uri=https:\/\/www.example.com\/oauth\/callback/
+    end
+
+    it 'should include the scope' do
+      expect(URI(uri).query).to match /scope=email%20profile/
+    end
+
+  end
+
+
+  context 'when generating authorization URLs with user ID & state' do
+    let(:uri) { authorizer.get_authorization_url(:login_hint => 'user1', :state => 'mystate') }
+
+    it_behaves_like 'valid authorization url'
+
+    it 'includes a login hint' do
+      expect(URI(uri).query).to match /login_hint=user1/
+    end
+
+    it 'includes the app state' do
+      expect(URI(uri).query).to match /state=mystate/
+    end
+  end
+
+  context 'when generating authorization URLs with user ID and no state' do
+    let(:uri) { authorizer.get_authorization_url(:login_hint => 'user1') }
+
+    it_behaves_like 'valid authorization url'
+
+    it 'includes a login hint' do
+      expect(URI(uri).query).to match /login_hint=user1/
+    end
+
+    it 'does not include the state parameter' do
+      expect(URI(uri).query).to_not match /state/
+    end
+  end
+
+  context 'when generating authorization URLs with no user ID and no state' do
+    let(:uri) { authorizer.get_authorization_url }
+
+    it_behaves_like 'valid authorization url'
+
+    it 'does not include the login hint parameter' do
+      expect(URI(uri).query).to_not match /login_hint/
+    end
+
+    it 'does not include the state parameter' do
+      expect(URI(uri).query).to_not match /state/
+    end
+  end
+
+  context 'when retrieving tokens' do
+    let(:token_json) do
+      MultiJson.dump({
+        access_token: 'accesstoken',
+        refresh_token: 'refreshtoken',
+        expiration_time_millis: 1441234742000
+      })
+    end
+
+    context 'with a valid user id' do
+      let(:credentials) do
+        token_store.store('user1', token_json)
+        authorizer.get_credentials('user1')
+      end
+
+      it 'should return an instance of UserRefreshCredentials' do
+        expect(credentials).to be_instance_of(Google::Auth::UserRefreshCredentials)
+      end
+
+      it 'should return credentials with a valid refresh token' do
+        expect(credentials.refresh_token).to eq 'refreshtoken'
+      end
+
+      it 'should return credentials with a valid access token' do
+        expect(credentials.access_token).to eq 'accesstoken'
+      end
+
+      it 'should return credentials with a valid client ID' do
+        expect(credentials.client_id).to eq 'testclient'
+      end
+
+      it 'should return credentials with a valid client secret' do
+        expect(credentials.client_secret).to eq 'notasecret'
+      end
+
+      it 'should return credentials with a valid scope' do
+        expect(credentials.scope).to eq %w(email profile)
+      end
+
+      it 'should return credentials with a valid expiration time' do
+        expect(credentials.expires_at).to eq Time.at(1441234742)
+      end
+    end
+
+    context 'with an invalid user id' do
+      it 'should return nil' do
+        expect(authorizer.get_credentials('notauser')).to be_nil
+      end
+    end
+  end
+
+  context 'when saving tokens' do
+    let(:expiry) {  Time.now.to_i }
+    let(:credentials) do
+      Google::Auth::UserRefreshCredentials.new(
+        client_id: client_id.id,
+        client_secret: client_id.secret,
+        scope: scope,
+        refresh_token: 'refreshtoken',
+        access_token: 'accesstoken',
+        expires_at: expiry
+      )
+    end
+
+    let(:token_json) do
+      authorizer.store_credentials('user1', credentials)
+      token_store.load('user1')
+    end
+
+    it 'should persist in the token store' do
+      expect(token_json).to_not be_nil
+    end
+
+    it 'should persist the refresh token' do
+      expect(MultiJson.load(token_json)['refresh_token']).to eq 'refreshtoken'
+    end
+
+    it 'should persist the access token' do
+      expect(MultiJson.load(token_json)['access_token']).to eq 'accesstoken'
+    end
+
+    it 'should persist the client id' do
+      expect(MultiJson.load(token_json)['client_id']).to eq 'testclient'
+    end
+
+    it 'should persist the scope' do
+      expect(MultiJson.load(token_json)['scope']).to include('email', 'profile')
+    end
+
+    it 'should persist the expiry as milliseconds' do
+      expect(MultiJson.load(token_json)['expiration_time_millis']).to eql (expiry * 1000)
+    end
+
+  end
+
+  context 'with valid authorization code' do
+    let(:token_json) do
+      MultiJson.dump('access_token' => '1/abc123',
+                     'token_type' => 'Bearer',
+                     'expires_in' => 3600)
+    end
+
+    before(:example) do
+      stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').to_return(
+        :body => token_json, :status => 200, :headers => { 'Content-Type' => 'application/json' })
+    end
+
+    it 'should exchange a code for credentials' do
+      credentials = authorizer.get_credentials_from_code(:user_id => 'user1', :code => 'code')
+      expect(credentials.access_token).to eq '1/abc123'
+    end
+
+    it 'should not store credentials when get only requested' do
+      credentials = authorizer.get_credentials_from_code(:user_id => 'user1', :code => 'code')
+      expect(token_store.load('user1')).to be_nil
+    end
+
+    it 'should store credentials when requested' do
+      credentials = authorizer.get_and_store_credentials_from_code(:user_id => 'user1', :code => 'code')
+      expect(token_store.load('user1')).to_not be_nil
+    end
+  end
+
+  context 'with invalid authorization code' do
+    before(:example) do
+      stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').to_return(:status => 400)
+    end
+
+    it 'should raise an authorization error' do
+      expect { authorizer.get_credentials_from_code(:user_id => 'user1', :code => 'badcode') }.to raise_error Signet::AuthorizationError
+    end
+
+    it 'should not store credentials when exchange fails' do
+      expect{authorizer.get_credentials_from_code(:user_id => 'user1', :code => 'badcode') }.to raise_error Signet::AuthorizationError
+      expect(token_store.load('user1')).to be_nil
+    end
+  end
+
+  context 'when reovking authorization' do
+    let(:token_json) do
+      MultiJson.dump({
+        access_token: 'accesstoken',
+        refresh_token: 'refreshtoken',
+        expiration_time_millis: 1441234742000
+      })
+    end
+
+    before(:example) do
+      token_store.store('user1', token_json)
+      stub_request(:get, 'https://accounts.google.com/o/oauth2/revoke?token=refreshtoken').to_return(:status => 200)
+    end
+
+    it 'should revoke the grant' do
+      authorizer.revoke_authorization('user1')
+      expect(a_request(:get, 'https://accounts.google.com/o/oauth2/revoke?token=refreshtoken')).to have_been_made
+    end
+
+    it 'should remove the token from storage' do
+      authorizer.revoke_authorization('user1')
+      expect(token_store.load('user1')).to be_nil
+    end
+
+  end
+
+  # TODO - Test that tokens are monitored
+  # TODO - Test scope enforcement (auth if upgrade required)
+
+end

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -57,7 +57,7 @@ describe Google::Auth::UserRefreshCredentials do
 
   before(:example) do
     @key = OpenSSL::PKey::RSA.new(2048)
-    @client = UserRefreshCredentials.new(
+    @client = UserRefreshCredentials.make_creds(
       json_key_io: StringIO.new(cred_json_text),
       scope: 'https://www.googleapis.com/auth/userinfo.profile'
     )
@@ -142,10 +142,11 @@ describe Google::Auth::UserRefreshCredentials do
       ENV[CLIENT_SECRET_VAR] = cred_json[:client_secret]
       ENV[REFRESH_TOKEN_VAR] = cred_json[:refresh_token]
       ENV[ACCOUNT_TYPE_VAR] = cred_json[:type]
-      expect(@clz.from_env(@scope)).to_not be_nil
-      expect(subject.client_id).to eq(cred_json[:client_id])
-      expect(subject.client_secret).to eq(cred_json[:client_secret])
-      expect(subject.refresh_token).to eq(cred_json[:refresh_token])
+      creds = @clz.from_env(@scope)
+      expect(creds).to_not be_nil
+      expect(creds.client_id).to eq(cred_json[:client_id])
+      expect(creds.client_secret).to eq(cred_json[:client_secret])
+      expect(creds.refresh_token).to eq(cred_json[:refresh_token])
     end
   end
 
@@ -227,4 +228,88 @@ describe Google::Auth::UserRefreshCredentials do
       end
     end
   end
+  
+  shared_examples 'revoked token' do
+    it 'should nil the refresh token' do
+      expect(@client.refresh_token).to be_nil
+    end
+
+    it 'should nil the access token' do
+      expect(@client.access_token).to be_nil
+    end
+    
+    it 'should mark the token as expired' do
+      expect(@client.expired?).to be_truthy
+    end
+  end
+  
+  describe 'when revoking a refresh token' do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/o/oauth2/revoke') do |env|
+          expect(env.params['token']).to eql 'refreshtoken'
+          [200]
+        end
+      end
+    end
+    
+    let(:connection) do
+      Faraday.new do |c|
+        c.adapter(:test, stubs)
+      end
+    end
+
+    before(:example) do
+      @client.revoke!(connection: connection)
+    end
+    
+    it_behaves_like 'revoked token'
+  end
+
+  describe 'when revoking an access token' do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/o/oauth2/revoke') do |env|
+          expect(env.params['token']).to eql 'accesstoken'
+          [200]
+        end
+      end
+    end
+    
+    let(:connection) do
+      Faraday.new do |c|
+        c.adapter(:test, stubs)
+      end
+    end
+
+    before(:example) do
+      @client.refresh_token = nil
+      @client.access_token = 'accesstoken'
+      @client.revoke!(connection: connection)
+    end
+
+    it_behaves_like 'revoked token'
+  end
+  
+  describe 'when revoking an invalid token' do
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/o/oauth2/revoke') do |env|
+          [400]
+        end
+      end
+    end
+    
+    let(:connection) do
+      Faraday.new do |c|
+        c.adapter(:test, stubs)
+      end
+    end
+
+    it 'raises an authorization error' do
+      expect { @client.revoke!(connection: connection) }.to raise_error Signet::AuthorizationError
+    end
+  end
+  
+  
 end

--- a/spec/googleauth/web_user_authorizer_spec.rb
+++ b/spec/googleauth/web_user_authorizer_spec.rb
@@ -1,0 +1,143 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
+$LOAD_PATH.unshift(spec_dir)
+$LOAD_PATH.uniq!
+
+require 'googleauth'
+require 'googleauth/web_user_authorizer'
+require 'uri'
+require 'multi_json'
+require 'spec_helper'
+require 'rack'
+
+
+describe Google::Auth::WebUserAuthorizer do
+  include TestHelpers
+
+  let(:client_id) { Google::Auth::ClientId.new('testclient', 'notasecret') }
+  let(:scope) { ['email', 'profile'] }
+  let(:token_store) { DummyTokenStore.new }
+  let(:authorizer) do
+    Google::Auth::WebUserAuthorizer.new(client_id, scope, token_store)
+  end
+
+  describe '#get_authorization_url' do
+    let(:env) { Rack::MockRequest.env_for("http://example.com:8080/test", {"REMOTE_ADDR" => "10.10.10.10"})}
+    let(:request) { Rack::Request.new(env) }
+    it 'should include current url in state' do
+      url = authorizer.get_authorization_url(:request => request)
+      expect(url).to match(/%22current_uri%22:%22http:\/\/example.com:8080\/test%22/)
+    end
+
+    it 'should include request forgery token in state' do
+      expect(SecureRandom).to receive(:base64).and_return('aGVsbG8=')
+      url = authorizer.get_authorization_url(:request => request)
+      expect(url).to match(/%22session_id%22:%22aGVsbG8=%22/)
+    end
+
+    it 'should include request forgery token in session' do
+      expect(SecureRandom).to receive(:base64).and_return('aGVsbG8=')
+      url = authorizer.get_authorization_url(:request => request)
+      expect(request.session['g-xsrf-token']).to eq 'aGVsbG8='
+    end
+
+    it 'should resolve callback against base URL' do
+      url = authorizer.get_authorization_url(:request => request)
+      expect(url).to match(/redirect_uri=http:\/\/example.com:8080\/oauth2callback/)
+    end
+
+    it 'should allow overriding the current URL' do
+      url = authorizer.get_authorization_url(:request => request, :redirect_to => '/foo')
+      expect(url).to match(/%22current_uri%22:%22\/foo%22/)
+    end
+
+    it 'should pass through login hint' do
+      url = authorizer.get_authorization_url(:request => request, :login_hint => 'user@example.com')
+      expect(url).to match(/login_hint=user@example.com/)
+    end
+  end
+
+  shared_examples 'handles callback' do
+    let(:token_json) do
+      MultiJson.dump('access_token' => '1/abc123',
+                     'token_type' => 'Bearer',
+                     'expires_in' => 3600)
+    end
+
+    before(:example) do
+      stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').to_return(
+        :body => token_json, :status => 200, :headers => { 'Content-Type' => 'application/json' })
+    end
+
+    let(:env) do
+      Rack::MockRequest.env_for(
+        "http://example.com:8080/oauth2callback?code=authcode&state=%7B%22current_uri%22%3A%22%2Ffoo%22%2C%22session_id%22%3A%22abc%22%7D",
+        { "REMOTE_ADDR" => "10.10.10.10" }
+      )
+    end
+    let(:request) { Rack::Request.new(env) }
+
+    before(:example) do
+      request.session['g-xsrf-token'] = 'abc'
+    end
+
+    it 'should return credentials when valid code present' do
+      expect(credentials).to be_instance_of(Google::Auth::UserRefreshCredentials)
+    end
+
+    it 'should return next URL to redirect to' do
+      expect(next_url).to eq '/foo'
+    end
+
+    it 'should fail if xrsf token in session and does not match request' do
+      request.session['g-xsrf-token'] = '123'
+      expect { credentials }.to raise_error(Signet::AuthorizationError)
+    end
+  end
+
+  describe '#handle_auth_callback' do
+    let(:result) { authorizer.handle_auth_callback('user1', request) }
+    let(:credentials) { result[0] }
+    let(:next_url) { result[1] }
+
+    it_behaves_like 'handles callback'
+  end
+
+  describe '#handle_auth_callback_deferred and #get_credentials' do
+    let(:next_url) { Google::Auth::WebUserAuthorizer.handle_auth_callback_deferred(request) }
+    let(:credentials) do
+      next_url
+      authorizer.get_credentials('user1', request)
+    end
+
+    it_behaves_like 'handles callback'
+  end
+end


### PR DESCRIPTION
3LO implementation based on google/google-auth-library-java#39 and google/google-auth-library-java#36 as well as some ruby-specific features (e.g. Rails support) and a few other items migrated from from https://github.com/google/google-api-ruby-client (redis store, installed app flow)

Still a few todos, but close enough that I'd like to get comments/feedback to see if there are any major changes needed before cleaning things up.

TODOs:

- [ ] Clean up any rubocop errors
- [ ] Fill in some missing test cases
- [ ] More docs/samples