### PR TITLE
3LO - Installed app support

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'signet', '~> 0.6'
+  s.add_dependency 'launchy', '~> 2.4'
 end

--- a/lib/googleauth.rb
+++ b/lib/googleauth.rb
@@ -37,6 +37,7 @@ require 'googleauth/user_refresh'
 require 'googleauth/client_id'
 require 'googleauth/user_authorizer'
 require 'googleauth/web_user_authorizer'
+require 'googleauth/installed_app_user_authorizer'
 
 module Google
   # Module Auth provides classes that provide Google-specific authorization

--- a/lib/googleauth/installed_app_user_authorizer.rb
+++ b/lib/googleauth/installed_app_user_authorizer.rb
@@ -1,0 +1,224 @@
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'webrick'
+require 'launchy'
+
+module Google
+  module Auth
+    # Varation on {Google::Auth::UserAuthorizer} adapted command line
+    # scripts.
+    #
+    # Example usage using browser/embedded server:
+    #
+    #     credentials = authorizer.get_credentials('user@gmail.com') do |auth|
+    #       auth.authorize_with_local_server
+    #     end
+    #
+    # Requests that require authorization will start an embedded
+    # web server on localhost and launch the user's browser. If unable to
+    # launch a browser locally, out-of-band authorization can be performed:
+    #
+    # Example of out of band authorization:
+    #
+    #     credentials = authorizer.get_credentials('user@gmail.com') do |auth|
+    #       url = auth.oob_auth_url
+    #       puts "Open #{url} and enter the authorization code here "\
+    #            "after authorizing the application."
+    #       gets
+    #     end
+    #
+    # @see {Google::Auth::AuthCallbackApp}
+    class InstalledAppUserAuthorizer < Google::Auth::UserAuthorizer
+      # Initialize the authorizer
+      #
+      # @param [Google::Auth::ClientID] client_id
+      #  Configured ID & secret for this application
+      # @param [String, Array<String>] scope
+      #  Authorization scope to request
+      # @param [Google::Auth::Stores::TokenStore] token_store
+      #  Backing storage for persisting user credentials
+      def initialize(client_id, scope, token_store = nil)
+        super(client_id, scope, token_store, nil)
+      end
+
+      # Get credentials for the the user. A block may be provided
+      # to handle the case when credentials are not present.
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials. Preference
+      #  is to use the email address of the google account.
+      # @yield [String] Authorization URL
+      # @param [Array<String>, String] scope
+      #  If specified, only returns credentials that have all
+      #  the requested scopes
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  User credentials
+      # @yield [auth] Block to acquire the authorization code.
+      # @yieldparam [AuthContext] auth
+      # @yieldreturn [String] authorization code
+      # @see {#request_authorization}
+      def get_credentials(user_id, scope = nil, &block)
+        credentials = super(user_id)
+        if credentials.nil? && block_given?
+          credentials = request_authorization(user_id, scope, &block)
+        end
+        credentials
+      end
+
+      # Request authorization. Does not check for existing credentials.
+      #
+      # Example usage using browser/embedded server:
+      #
+      #     creds = authorizer.request_authorization('user@gmail.com') do |auth|
+      #       auth.authorize_with_local_server
+      #     end
+      #
+      # Requests that require authorization will start an embedded
+      # web server on localhost and launch the user's browser. If unable to
+      # launch a browser locally, out-of-band authorization can be performed:
+      #
+      # Example of out of band authorization:
+      #
+      #     creds = authorizer.request_authorization('user@gmail.com') do |auth|
+      #       url = auth.oob_auth_url
+      #       puts "Open #{url} and enter the authorization code here "\
+      #            "after authorizing the application."
+      #       gets
+      #     end
+      #
+      # @param [String] user_id
+      #  Unique ID of the user for loading/storing credentials.
+      # @yield [auth] Block to acquire the authorization code.
+      # @param [Array<String>, String] scope
+      #  Authorization scope to request. Overrides the instance scopes if not
+      #  nil.
+      # @yieldparam [AuthContext] auth
+      # @yieldreturn [String] authorization code
+      # @return [Google::Auth::UserRefreshCredentials]
+      #  User credentials
+      def request_authorization(user_id, scope = nil, &block)
+        fail 'Block required' if block.nil?
+        context = AuthContext.new(self, user_id, scope)
+        code = block.call(context)
+        return context.exchange_code(code) if code
+        nil
+      end
+
+      # Helper passed to callbacks for performing the actual authorization.
+      # Provides a choice between OOB mode or using a local webserver
+      # for callbacks
+      class AuthContext
+        OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+
+        def initialize(authorizer, user_id, scope)
+          @authorizer = authorizer
+          @user_id = user_id
+          @scope = scope
+          @base_url = OOB_URI
+        end
+
+        # Returns the authorization URL for out-of-band flows. It is the
+        # caller's responsibility to prompt the user to open the URL
+        # and enter the resulting code of the authorization process.
+        #
+        # @return [String] Url to acquire authorization
+        def oob_auth_url
+          @authorizer.get_authorization_url(login_hint: @user_id,
+                                            scope: @scope,
+                                            base_url: @base_url)
+        end
+
+        # Requests authorization, using an emebedded server on localhost
+        # to handle the callback.
+        #
+        # @param [Fixnum] local_port
+        #  Port to run local webserver on
+        # @return [String] authorization code
+        def authorize_with_local_server(local_port = nil)
+          local_port ||= 8081
+          @base_url = "http://localhost:#{local_port}"
+          auth_url = @authorizer.get_authorization_url(
+            login_hint: @user_id,
+            scope: @scope,
+            base_url: @base_url)
+          run_callback_server(local_port, auth_url)
+        end
+
+        # @param [String] code
+        #  Authorization code to exchange
+        # @return [Google::Auth::UserRefreshCredentials]
+        #  User credentials
+        # @see Google::Auth::UserAuthorizer#get_and_store_credentials_from_code
+        def exchange_code(code)
+          @authorizer.get_and_store_credentials_from_code(user_id: @user_id,
+                                                          code: code,
+                                                          base_url: @base_url)
+        end
+
+        private
+
+        RESPONSE_BODY = <<-HTML
+          <html>
+            <head>
+              <script>
+                function closeWindow() {
+                  window.open('', '_self', '');
+                  window.close();
+                }
+                setTimeout(closeWindow, 10);
+              </script>
+            </head>
+            <body>You may close this window.</body>
+          </html>
+        HTML
+
+        # Start an HTTP server to handle the authorization callback.
+        #
+        # @param [Fixnum] local_port
+        #  Port to run local webserver on
+        # @param [String] url
+        #  Authorization URL to launch browser for
+        def run_callback_server(local_port, url)
+          server = create_server(local_port)
+          code = nil
+          begin
+            trap('INT') { server.shutdown }
+            proc = lambda do |req, res|
+              code = req.query['code']
+              res.status = WEBrick::HTTPStatus::RC_ACCEPTED
+              res.body = RESPONSE_BODY
+              server.stop
+            end
+            server.mount_proc '/', &proc
+            Launchy.open(url)
+            server.start
+          ensure
+            server.shutdown
+          end
+          code
+        end
+
+        def create_server(local_port)
+          WEBrick::HTTPServer.new(
+            Port: local_port,
+            BindAddress: 'localhost',
+            Logger: WEBrick::Log.new(STDOUT, 0),
+            AccessLog: []
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/googleauth/installed_app_user_authorizer_spec.rb
+++ b/spec/googleauth/installed_app_user_authorizer_spec.rb
@@ -1,0 +1,135 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+spec_dir = File.expand_path(File.join(File.dirname(__FILE__)))
+$LOAD_PATH.unshift(spec_dir)
+$LOAD_PATH.uniq!
+
+require 'googleauth'
+require 'googleauth/user_authorizer'
+require 'uri'
+require 'multi_json'
+require 'spec_helper'
+
+describe Google::Auth::InstalledAppUserAuthorizer do
+  include TestHelpers
+
+  let(:client_id) { Google::Auth::ClientId.new('testclient', 'notasecret') }
+  let(:scope) { %w(email profile) }
+  let(:token_store) { DummyTokenStore.new }
+  let(:token_json) do
+    MultiJson.dump('access_token' => '1/abc123',
+                   'token_type' => 'Bearer',
+                   'expires_in' => 3600)
+  end
+
+  before(:example) do
+    token_store.store('user2@example.com', token_json)
+  end
+
+  before(:example) do
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token').to_return(
+      body: token_json,
+      status: 200,
+      headers: { 'Content-Type' => 'application/json' })
+  end
+
+  let(:authorizer) do
+    Google::Auth::InstalledAppUserAuthorizer.new(client_id, scope, token_store)
+  end
+
+  context 'when invoked for OOB mode' do
+    context 'with no saved credentials' do
+      it 'should prompt for authorization' do
+        expect do |b|
+          authorizer.get_credentials('user@example.com') do |auth|
+            b.to_proc.call(auth.oob_auth_url)
+            'code'
+          end
+        end.to yield_with_args(%r{https://accounts.google.com/.*})
+      end
+
+      it 'should return valid credentials' do
+        credentials = authorizer.get_credentials('user@example.com') do |_auth|
+          'code'
+        end
+        expect(credentials).to be_instance_of(
+          Google::Auth::UserRefreshCredentials)
+      end
+    end
+  end
+
+  context 'when invoked for local server mode' do
+    context 'with no saved credentials' do
+      let(:server) do
+        double('webrick', start: nil, stop: nil, shutdown: nil)
+      end
+
+      def mock_server(authorizer)
+        allow(authorizer).to receive(:create_server).and_return(server)
+        expect(server).to receive(:mount_proc) do |_url, &proc|
+          @proc = proc
+        end
+        expect(server).to receive(:start) do
+          request = double('request', query: { 'code' => 'authcode' })
+          response = double('response')
+          expect(response).to receive(:status=).with(202)
+          expect(response).to receive(:body=).with(String)
+          @proc.call(request, response)
+        end
+      end
+
+      let(:credentials) do
+        authorizer.get_credentials('user@example.com') do |auth|
+          mock_server(auth)
+          auth.authorize_with_local_server
+        end
+      end
+
+      it 'should prompt for authorization' do
+        expect(Launchy).to receive(:open).with(
+          %r{https://accounts.google.com/.*})
+        credentials
+      end
+
+      it 'should return valid credentials' do
+        allow(Launchy).to receive(:open).with(
+          %r{https://accounts.google.com/.*})
+        expect(credentials).to be_instance_of(
+          Google::Auth::UserRefreshCredentials)
+      end
+    end
+
+    it 'should return saved credentials' do
+      credentials = authorizer.get_credentials('user2@example.com')
+      expect(credentials).to be_instance_of(
+        Google::Auth::UserRefreshCredentials)
+    end
+  end
+end


### PR DESCRIPTION
Authorizer tailored to scripts/command line apps, ported from google-apis-ruby-client.

Strictly speaking, doesn't *need* to be a separate authorizer. OOB is fairly trivial to do with the plain UserAuthorizer and the embedded server part could be its own thing. But this does make it relatively trivial to implement CLIs that can switch modes easily...

```ruby
credentials = authorizer.get_credentials(options[:user] || 'default') do |auth|
  if options[:headless]
    puts "Open #{auth.oob_auth_url} to authorize and enter the provided code below:"
    gets
  else
    auth.authorize_with_local_server
  end
end
```
