### PR TITLE
Prep for 0.5 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - jruby
 matrix:
   allow_failures:
-    - rbx-2 # See rubinius/rubinius#3485 - rubocop segfaults
+    - rvm: rbx-2 # See rubinius/rubinius#3485 - rubocop segfaults
 script: "bundle exec rake"
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0 (12/10/2015)
+
+### Changes
+
+* Initial support for user credentials ([@sqrrrl][])
+* Update Signet to 0.7
+
 ## 0.4.2 (05/08/2015)
 
 ### Changes

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
   gem 'fakeredis', '~> 0.5'
   gem 'webmock', '~> 1.21'
   gem 'rack-test', '~> 0.6'
+  gem 'sinatra'
 end
 
 platforms :jruby do

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 1.4'
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
-  s.add_dependency 'signet', '~> 0.6'
+  s.add_dependency 'signet', '~> 0.7'
 end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -42,7 +42,7 @@ module Signet
       def apply!(a_hash, opts = {})
         # fetch the access token there is currently not one, or if the client
         # has expired
-        fetch_access_token!(opts) if access_token.nil? || expired?
+        fetch_access_token!(opts) if access_token.nil? || expires_within?(60)
         a_hash[AUTH_METADATA_KEY] = "Bearer #{access_token}"
       end
 
@@ -65,7 +65,7 @@ module Signet
       end
 
       alias_method :orig_fetch_access_token!, :fetch_access_token!
-      def fetch_access_token!(options)
+      def fetch_access_token!(options = {})
         info = orig_fetch_access_token!(options)
         notify_refresh_listeners
         info

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.4.2'
+    VERSION = '0.5.0'
   end
 end

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -44,16 +44,17 @@ module Google
     #       user_id = request.session['user_email']
     #       credentials = authorizer.get_credentials(user_id, request)
     #       if credentials.nil?
-    #         redirect authorizer.get_authorization_url(user_id: user_id, request: request)
+    #         redirect authorizer.get_authorization_url(user_id: user_id,
+    #                                                   request: request)
     #       end
     #       # Credentials are valid, can call APIs
     #       ...
     #    end
     #
     #    get('/oauth2callback') do
-    #       target_url = Google::Auth::WebUserAuthorizer.handle_auth_callback_deferred(
-    #         request)
-    #      redirect target_url
+    #      url = Google::Auth::WebUserAuthorizer.handle_auth_callback_deferred(
+    #        request)
+    #      redirect url
     #    end
     #
     # Instead of implementing the callback directly, applications are

--- a/lib/googleauth/web_user_authorizer.rb
+++ b/lib/googleauth/web_user_authorizer.rb
@@ -44,16 +44,16 @@ module Google
     #       user_id = request.session['user_email']
     #       credentials = authorizer.get_credentials(user_id, request)
     #       if credentials.nil?
-    #         redirect authorizer.get_redirect_uri(user_id, request)
+    #         redirect authorizer.get_authorization_url(user_id: user_id, request: request)
     #       end
     #       # Credentials are valid, can call APIs
     #       ...
     #    end
     #
     #    get('/oauth2callback') do
-    #       user_id = request.session['user_email']
-    #      _, return_uri = authorizer.handle_auth_callback(user_id, request)
-    #      redirect return_uri
+    #       target_url = Google::Auth::WebUserAuthorizer.handle_auth_callback_deferred(
+    #         request)
+    #      redirect target_url
     #    end
     #
     # Instead of implementing the callback directly, applications are

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -57,124 +57,101 @@ shared_examples 'apply/apply! are OK' do
   # auth client
   describe '#fetch_access_token' do
     let(:token) { '1/abcdef1234567890' }
-    let(:stubs) do
+    let(:stub) do
       make_auth_stubs access_token: token
-    end
-    let(:connection) do
-      Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
     end
 
     it 'should set access_token to the fetched value' do
-      @client.fetch_access_token!(connection: connection)
+      stub
+      @client.fetch_access_token!
       expect(@client.access_token).to eq(token)
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
 
     it 'should notify refresh listeners after updating' do
+      stub
       expect do |b|
         @client.on_refresh(&b)
-        @client.fetch_access_token!(connection: connection)
+        @client.fetch_access_token!
       end.to yield_with_args(have_attributes(
                                access_token: '1/abcdef1234567890'))
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
   end
 
   describe '#apply!' do
     it 'should update the target hash with fetched access token' do
       token = '1/abcdef1234567890'
-      stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
+      stub = make_auth_stubs access_token: token
 
       md = { foo: 'bar' }
-      @client.apply!(md, connection: c)
+      @client.apply!(md)
       want = { :foo => 'bar', auth_key => "Bearer #{token}" }
       expect(md).to eq(want)
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
   end
 
   describe 'updater_proc' do
     it 'should provide a proc that updates a hash with the access token' do
       token = '1/abcdef1234567890'
-      stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
-
+      stub = make_auth_stubs access_token: token
       md = { foo: 'bar' }
       the_proc = @client.updater_proc
-      got = the_proc.call(md, connection: c)
+      got = the_proc.call(md)
       want = { :foo => 'bar', auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
   end
 
   describe '#apply' do
     it 'should not update the original hash with the access token' do
       token = '1/abcdef1234567890'
-      stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
+      stub = make_auth_stubs access_token: token
 
       md = { foo: 'bar' }
-      @client.apply(md, connection: c)
+      @client.apply(md)
       want = { foo: 'bar' }
       expect(md).to eq(want)
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
 
     it 'should add the token to the returned hash' do
       token = '1/abcdef1234567890'
-      stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
+      stub = make_auth_stubs access_token: token
 
       md = { foo: 'bar' }
-      got = @client.apply(md, connection: c)
+      got = @client.apply(md)
       want = { :foo => 'bar', auth_key => "Bearer #{token}" }
       expect(got).to eq(want)
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
 
     it 'should not fetch a new token if the current is not expired' do
       token = '1/abcdef1234567890'
-      stubs = make_auth_stubs access_token: token
-      c = Faraday.new do |b|
-        b.adapter(:test, stubs)
-      end
+      stub = make_auth_stubs access_token: token
 
       n = 5 # arbitrary
       n.times do |_t|
         md = { foo: 'bar' }
-        got = @client.apply(md, connection: c)
+        got = @client.apply(md)
         want = { :foo => 'bar', auth_key => "Bearer #{token}" }
         expect(got).to eq(want)
       end
-      stubs.verify_stubbed_calls
+      expect(stub).to have_been_requested
     end
 
     it 'should fetch a new token if the current one is expired' do
       token_1 = '1/abcdef1234567890'
-      token_2 = '2/abcdef1234567890'
+      token_2 = '2/abcdef1234567891'
 
       [token_1, token_2].each do |t|
-        stubs = make_auth_stubs access_token: t
-        c = Faraday.new do |b|
-          b.adapter(:test, stubs)
-        end
+        make_auth_stubs access_token: t
         md = { foo: 'bar' }
-        got = @client.apply(md, connection: c)
+        got = @client.apply(md)
         want = { :foo => 'bar', auth_key => "Bearer #{t}" }
         expect(got).to eq(want)
-        stubs.verify_stubbed_calls
         @client.expires_at -= 3601 # default is to expire in 1hr
       end
     end

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -34,18 +34,6 @@ $LOAD_PATH.uniq!
 require 'faraday'
 require 'spec_helper'
 
-def build_json_response(payload)
-  [200,
-   { 'Content-Type' => 'application/json; charset=utf-8' },
-   MultiJson.dump(payload)]
-end
-
-def build_access_token_json(token)
-  build_json_response('access_token' => token,
-                      'token_type' => 'Bearer',
-                      'expires_in' => 3600)
-end
-
 shared_examples 'apply/apply! are OK' do
   let(:auth_key) { :Authorization }
 

--- a/spec/googleauth/signet_spec.rb
+++ b/spec/googleauth/signet_spec.rb
@@ -50,16 +50,21 @@ describe Signet::OAuth2::Client do
 
   def make_auth_stubs(opts)
     access_token = opts[:access_token] || ''
-    Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.post('/o/oauth2/token') do |env|
-        params = Addressable::URI.form_unencode(env[:body])
-        _claim, _header = JWT.decode(params.assoc('assertion').last,
-                                     @key.public_key)
-        want = ['grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer']
-        expect(params.assoc('grant_type')).to eq(want)
-        build_access_token_json(access_token)
-      end
+    body = MultiJson.dump('access_token' => access_token,
+                          'token_type' => 'Bearer',
+                          'expires_in' => 3600)
+    blk = proc do |request|
+      params = Addressable::URI.form_unencode(request.body)
+      _claim, _header = JWT.decode(params.assoc('assertion').last,
+                                   @key.public_key)
     end
+    stub_request(:post, 'https://accounts.google.com/o/oauth2/token')
+      .with(body: hash_including(
+        'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer'),
+            &blk)
+      .to_return(body: body,
+                 status: 200,
+                 headers: { 'Content-Type' => 'application/json' })
   end
 
   it_behaves_like 'apply/apply! are OK'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,6 @@ $LOAD_PATH.unshift(spec_dir)
 $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.uniq!
 
-
 # set up coverage
 require 'simplecov'
 require 'coveralls'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,11 +35,15 @@ $LOAD_PATH.unshift(spec_dir)
 $LOAD_PATH.unshift(lib_dir)
 $LOAD_PATH.uniq!
 
+
 # set up coverage
 require 'simplecov'
 require 'coveralls'
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.formatters = [
+  Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::HTMLFormatter
+]
 SimpleCov.start
 
 require 'faraday'


### PR DESCRIPTION
Updates to release 0.5 for the user authorizer functionality.

Includes updates to tests to use webmock instead of Faraday stubs. Using faraday's stubs turns out to be fragile as data isn't fully normalized (content of env changes depending on the style of the call, even if they're semantically equivalent.) Using webmock ends up being simpler and safer anyway.

