### PR TITLE
Fix for ADC not working on some windows machines

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '~> 1.4'
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
+  s.add_dependency 'os', '~> 0.9'
   s.add_dependency 'signet', '~> 0.7'
 end

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'memoist'
+require 'os'
 require 'rbconfig'
 
 module Google
@@ -54,12 +55,6 @@ module Google
       WELL_KNOWN_ERROR = 'Unable to read the default credential file'
 
       SYSTEM_DEFAULT_ERROR = 'Unable to read the system default credential file'
-
-      # determines if the current OS is windows
-      def windows?
-        RbConfig::CONFIG['host_os'] =~ /Windows|mswin/
-      end
-      memoize :windows?
 
       # make_creds proxies the construction of a credentials instance
       #
@@ -91,10 +86,10 @@ module Google
       #
       # @param scope [string|array|nil] the scope(s) to access
       def from_well_known_path(scope = nil)
-        home_var = windows? ? 'APPDATA' : 'HOME'
+        home_var = OS.windows? ? 'APPDATA' : 'HOME'
         base = WELL_KNOWN_PATH
         root = ENV[home_var].nil? ? '' : ENV[home_var]
-        base = File.join('.config', base) unless windows?
+        base = File.join('.config', base) unless OS.windows?
         path = File.join(root, base)
         return nil unless File.exist?(path)
         File.open(path) do |f|
@@ -108,7 +103,7 @@ module Google
       #
       # @param scope [string|array|nil] the scope(s) to access
       def from_system_default_path(scope = nil)
-        if windows?
+        if OS.windows?
           return nil unless ENV['ProgramData']
           prefix = File.join(ENV['ProgramData'], 'Google/Auth')
         else


### PR DESCRIPTION
Fix for https://github.com/google/google-auth-library-ruby/issues/55

Currently only some of the possible host_os values (i.e. Windows and mswin) are used to identify whether the library is running on a windows machine. There are many other possible values that could signify a windows machine. E.g. my machine has 'mingw32'. Using the OS.windows? seems like a more reliable way to identify this.

Please note: this fix is for representational purposes only. I have validated the code fragments individually on my machine, but I haven't validated it by building this full repo.