### PR TITLE
Use lowercase :authorization for metadata key

### DIFF
--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -32,7 +32,7 @@ require 'signet/oauth_2/client'
 module Signet
   # OAuth2 supports OAuth2 authentication.
   module OAuth2
-    AUTH_METADATA_KEY = :Authorization
+    AUTH_METADATA_KEY = :authorization
     # Signet::OAuth2::Client creates an OAuth2 client
     #
     # This reopens Client to add #apply and #apply! methods which update a

--- a/spec/googleauth/apply_auth_examples.rb
+++ b/spec/googleauth/apply_auth_examples.rb
@@ -35,7 +35,7 @@ require 'faraday'
 require 'spec_helper'
 
 shared_examples 'apply/apply! are OK' do
-  let(:auth_key) { :Authorization }
+  let(:auth_key) { :authorization }
 
   # tests that use these examples need to define
   #


### PR DESCRIPTION
This makes the library HTTP2-compatible without breaking HTTP/1.1 support.