### PR TITLE
Fix uninitialized constant in DefaultCredentials

### DIFF
--- a/lib/googleauth.rb
+++ b/lib/googleauth.rb
@@ -70,7 +70,7 @@ END
       def self.read_creds
         env_var = CredentialsLoader::ACCOUNT_TYPE_VAR
         type = ENV[env_var]
-        fail "#{ACCOUNT_TYPE_VAR} is undefined in env" unless type
+        fail "#{env_var} is undefined in env" unless type
         case type
         when 'service_account'
           ServiceAccountCredentials


### PR DESCRIPTION
In DefaultCredentials.read_creds, when the environment variable referenced by CredentialsLoader::ACCOUNT_TYPE_VAR is not set, the resulting error message used the unqualified constant ACCOUNT_TYPE_VAR. That was giving an uninitialized constant error.