### PR TITLE
Use newest token cred uri

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -46,7 +46,7 @@ module Google
     #
     # cf [Application Default Credentials](http://goo.gl/mkAHpZ)
     class ServiceAccountCredentials < Signet::OAuth2::Client
-      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v3/token'
+      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v4/token'
       extend CredentialsLoader
 
       # Creates a ServiceAccountCredentials.
@@ -119,7 +119,7 @@ module Google
     class ServiceAccountJwtHeaderCredentials
       JWT_AUD_URI_KEY = :jwt_aud_uri
       AUTH_METADATA_KEY = Signet::OAuth2::AUTH_METADATA_KEY
-      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v3/token'
+      TOKEN_CRED_URI = 'https://www.googleapis.com/oauth2/v4/token'
       SIGNING_ALGORITHM = 'RS256'
       EXPIRY = 60
       extend CredentialsLoader

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -137,7 +137,7 @@ describe Google::Auth::ServiceAccountCredentials do
       _claim, _header = JWT.decode(params.assoc('assertion').last,
                                    @key.public_key)
     end
-    stub_request(:post, 'https://www.googleapis.com/oauth2/v3/token')
+    stub_request(:post, 'https://www.googleapis.com/oauth2/v4/token')
       .with(body: hash_including(
         'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer'),
             &blk)


### PR DESCRIPTION
Accordingly to [this doc](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests) token cred uri should be - https://www.googleapis.com/oauth2/v4/token

These changes fix access issues for some Google API's (http://stackoverflow.com/questions/35623453/cant-access-marketplace-license-api-with-service-account)
