### PR TITLE
Require new signet for jwt 2 compatibility

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'os', '~> 0.9'
-  s.add_dependency 'signet', '~> 0.7'
+  s.add_dependency 'signet', '~> 0.8'
 end

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'os', '~> 0.9'
-  s.add_dependency 'signet', '~> 0.8'
+  s.add_dependency 'signet', '~> 0.8', '>= 0.8.1'
 end


### PR DESCRIPTION
Signet 0.8 is required for compatibility with jwt >= 2.0