### PR TITLE
Fix latest Rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/MethodLength:
   Max: 20
 Metrics/ClassLength:
   Enabled: false
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Enabled: false
 Style/FormatString:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development do
   gem 'rake', '~> 10.0'
   gem 'redis', '~> 3.2'
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '>= 0.41', '< 0.50'
+  gem 'rubocop', '~> 0.50'
   gem 'simplecov', '~> 0.9'
   gem 'sinatra'
   gem 'webmock', '~> 1.21'

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/google/google-auth-library-ruby'
   s.summary       = 'Google Auth Library for Ruby'
   s.license       = 'Apache-2.0'
-  s.description   = <<-eos
+  s.description   = <<-DESCRIPTION
    Allows simple authorization for accessing Google APIs.
    Provide support for Application Default Credentials, as described at
    https://developers.google.com/accounts/docs/application-default-credentials
-  eos
+  DESCRIPTION
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")

--- a/lib/googleauth/compute_engine.rb
+++ b/lib/googleauth/compute_engine.rb
@@ -35,16 +35,16 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    NO_METADATA_SERVER_ERROR = <<END.freeze
+    NO_METADATA_SERVER_ERROR = <<ERROR_MESSAGE.freeze
 Error code 404 trying to get security access token
 from Compute Engine metadata for the default service account. This
 may be because the virtual machine instance does not have permission
 scopes specified.
-END
-    UNEXPECTED_ERROR_SUFFIX = <<END.freeze
+ERROR_MESSAGE
+    UNEXPECTED_ERROR_SUFFIX = <<ERROR_MESSAGE.freeze
 trying to get security access token from Compute Engine metadata for
 the default service account
-END
+ERROR_MESSAGE
 
     # Extends Signet::OAuth2::Client so that the auth token is obtained from
     # the GCE metadata server.

--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -106,7 +106,7 @@ module Google
           unless ENV[v].nil?
             begin
               JSON.parse ENV[v]
-            rescue
+            rescue StandardError
               nil
             end
           end

--- a/lib/googleauth/signet.rb
+++ b/lib/googleauth/signet.rb
@@ -83,11 +83,9 @@ module Signet
 
         begin
           yield
-        rescue => e
-          if e.is_a?(Signet::AuthorizationError) || e.is_a?(Signet::ParseError)
-            raise e
-          end
-
+        rescue Signet::AuthorizationError, Signet::ParseError
+          raise
+        rescue StandardError => e
           if retry_count < max_retry_count
             retry_count += 1
             sleep retry_count * 0.3


### PR DESCRIPTION
Style fixes that let us unpin rubocop and update it to 0.50.