### PR TITLE
Fix Credentials.default

### DIFF
--- a/lib/googleauth/credentials.rb
+++ b/lib/googleauth/credentials.rb
@@ -84,7 +84,7 @@ module Google
         client ||= from_json_vars(scope)
 
         # Third try to find keyfile file from known file paths.
-        client ||= from_default_vars(scope)
+        client ||= from_default_paths(scope)
 
         # Finally get instantiated client from Google::Auth
         client ||= from_application_default(scope)
@@ -99,6 +99,7 @@ module Google
           .each do |file|
             return new file, scope: scope
           end
+        nil
       end
 
       def self.from_json_vars(scope)
@@ -114,6 +115,7 @@ module Google
         self::JSON_ENV_VARS.map(&json).compact.each do |hash|
           return new hash, scope: scope
         end
+        nil
       end
 
       def self.from_default_paths(scope)
@@ -122,6 +124,7 @@ module Google
           .each do |file|
             return new file, scope: scope
           end
+        nil
       end
 
       def self.from_application_default(scope)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,8 @@ RSpec.configure do |config|
   include RSpec::LoggingHelper
   config.capture_log_messages
   config.include WebMock::API
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end
 
 module TestHelpers


### PR DESCRIPTION
Credentials.default has a bug where it returns an empty array if no matches were found when looking up keyfile info in `PATH_ENV_VARS`, `JSON_ENV_VARS`, or `DEFAULT_PATHS`. This is because of how the implementation was changed when migrating from google-cloud-ruby. The fix is to return `nil` if no matches are found from the various lookup methods.