### PR TITLE
Unescape private_key loaded from ENV

### DIFF
--- a/lib/googleauth/service_account.rb
+++ b/lib/googleauth/service_account.rb
@@ -58,7 +58,7 @@ module Google
         if json_key_io
           private_key, client_email = read_json_key(json_key_io)
         else
-          private_key = ENV[CredentialsLoader::PRIVATE_KEY_VAR]
+          private_key = unescape ENV[CredentialsLoader::PRIVATE_KEY_VAR]
           client_email = ENV[CredentialsLoader::CLIENT_EMAIL_VAR]
         end
 
@@ -76,6 +76,15 @@ module Google
         raise 'missing client_email' unless json_key.key?('client_email')
         raise 'missing private_key' unless json_key.key?('private_key')
         [json_key['private_key'], json_key['client_email']]
+      end
+
+      # Handles certain escape sequences that sometimes appear in input.
+      # Specifically, interprets the "\n" sequence for newline, and removes
+      # enclosing quotes.
+      def self.unescape(str)
+        str = str.gsub '\n', "\n"
+        str = str[1..-2] if str.start_with?('"') && str.end_with?('"')
+        str
       end
 
       def initialize(options = {})

--- a/spec/googleauth/service_account_spec.rb
+++ b/spec/googleauth/service_account_spec.rb
@@ -211,6 +211,13 @@ describe Google::Auth::ServiceAccountCredentials do
       ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
       expect(@clz.from_env(@scope)).to_not be_nil
     end
+
+    it 'succeeds when GOOGLE_PRIVATE_KEY is escaped' do
+      escaped_key = cred_json[:private_key].gsub "\n", '\n'
+      ENV[PRIVATE_KEY_VAR] = "\"#{escaped_key}\""
+      ENV[CLIENT_EMAIL_VAR] = cred_json[:client_email]
+      expect(@clz.from_env(@scope)).to_not be_nil
+    end
   end
 
   describe '#from_well_known_path' do


### PR DESCRIPTION
Alternative to https://github.com/google/google-auth-library-ruby/pull/88 that doesn't fail earlier tests. Unescapes only the specific `\n` sequence, and doesn't convert existing newlines to plain space characters. Also removes enclosing quotes if present.