### PR TITLE
Update os gem dependency

### DIFF
--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '>= 1.4', '< 3.0'
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
-  s.add_dependency 'os', '~> 0.9'
+  s.add_dependency 'os', '~> 1.0'
   s.add_dependency 'signet', '~> 0.7'
 end

--- a/googleauth.gemspec
+++ b/googleauth.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'jwt', '>= 1.4', '< 3.0'
   s.add_dependency 'memoist', '~> 0.12'
   s.add_dependency 'multi_json', '~> 1.11'
-  s.add_dependency 'os', '~> 1.0'
+  s.add_dependency 'os', '>= 0.9', '< 2.0'
   s.add_dependency 'signet', '~> 0.7'
 end


### PR DESCRIPTION
Was lead here because my `bundle outdated` showed this was out of date on my app. No breaking changes in the changelog for this gem, so it should be a trivial change.