### PR TITLE
Fix sdk credentials warning

### DIFF
--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -134,7 +134,7 @@ module Google
       def warn_if_cloud_sdk_credentials(client_id)
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
-      module_method :warn_if_cloud_sdk_credentials
+      module_function :warn_if_cloud_sdk_credentials
 
       private
 

--- a/lib/googleauth/credentials_loader.rb
+++ b/lib/googleauth/credentials_loader.rb
@@ -134,6 +134,7 @@ module Google
       def warn_if_cloud_sdk_credentials(client_id)
         warn CLOUD_SDK_CREDENTIALS_WARNING if client_id == CLOUD_SDK_CLIENT_ID
       end
+      module_method :warn_if_cloud_sdk_credentials
 
       private
 

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.6.2'.freeze
   end
 end


### PR DESCRIPTION
Some of the call sites are calling `CredentialsLoader.warn_if_cloud_sdk_credentials` as a module method. Need to define the method on the module object.

Also bumped the version number because the latest release is actually 0.6.2. It looks like the last time this was released, the update didn't get committed and tagged.