### PR TITLE
fix CLIENT_ID_VAR reference in DefaultCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4 (2018/08/03)
+
+* Resolve issue where DefaultCredentials constant was undefined.
+
 ## 0.6.3 (2018/08/02)
 
 * Resolve issue where token_store was being written to twice

--- a/lib/googleauth/default_credentials.rb
+++ b/lib/googleauth/default_credentials.rb
@@ -53,7 +53,7 @@ module Google
           clz.make_creds(json_key_io: StringIO.new(MultiJson.dump(json_key)),
                          scope: scope)
         else
-          warn_if_cloud_sdk_credentials ENV[CLIENT_ID_VAR]
+          warn_if_cloud_sdk_credentials ENV[CredentialsLoader::CLIENT_ID_VAR]
           clz = read_creds
           clz.make_creds(scope: scope)
         end

--- a/lib/googleauth/version.rb
+++ b/lib/googleauth/version.rb
@@ -31,6 +31,6 @@ module Google
   # Module Auth provides classes that provide Google-specific authorization
   # used to access Google APIs.
   module Auth
-    VERSION = '0.6.3'.freeze
+    VERSION = '0.6.4'.freeze
   end
 end


### PR DESCRIPTION
Fix for https://github.com/google/google-auth-library-ruby/issues/153