### PR TITLE
Fix auth token revocation (broken since 0.6.3)

### DIFF
--- a/lib/googleauth/user_refresh.rb
+++ b/lib/googleauth/user_refresh.rb
@@ -94,7 +94,7 @@ module Google
         c = options[:connection] || Faraday.default_connection
 
         retry_with_error do
-          resp = c.get(REVOKE_TOKEN_URI, token: refresh_token || access_token)
+          resp = c.post(REVOKE_TOKEN_URI, token: refresh_token || access_token)
           case resp.status
           when 200
             self.access_token = nil

--- a/spec/googleauth/user_authorizer_spec.rb
+++ b/spec/googleauth/user_authorizer_spec.rb
@@ -299,17 +299,17 @@ describe Google::Auth::UserAuthorizer do
 
     before(:example) do
       token_store.store('user1', token_json)
-      stub_request(
-        :get, 'https://oauth2.googleapis.com/revoke?token=refreshtoken'
-      )
+      stub_request(:post, 'https://oauth2.googleapis.com/revoke')
+        .with(body: hash_including('token' => 'refreshtoken'))
         .to_return(status: 200)
     end
 
     it 'should revoke the grant' do
       authorizer.revoke_authorization('user1')
       expect(a_request(
-               :get, 'https://oauth2.googleapis.com/revoke?token=refreshtoken'
-      ))
+               :post, 'https://oauth2.googleapis.com/revoke'
+             ).with(body: hash_including('token' => 'refreshtoken'))
+      )
         .to have_been_made
     end
 

--- a/spec/googleauth/user_refresh_spec.rb
+++ b/spec/googleauth/user_refresh_spec.rb
@@ -246,8 +246,8 @@ describe Google::Auth::UserRefreshCredentials do
 
   describe 'when revoking a refresh token' do
     let(:stub) do
-      stub_request(:get, 'https://oauth2.googleapis.com/revoke' \
-                         '?token=refreshtoken')
+      stub_request(:post, 'https://oauth2.googleapis.com/revoke')
+        .with(body: hash_including('token' => 'refreshtoken'))
         .to_return(status: 200,
                    headers: { 'Content-Type' => 'application/json' })
     end
@@ -262,8 +262,8 @@ describe Google::Auth::UserRefreshCredentials do
 
   describe 'when revoking an access token' do
     let(:stub) do
-      stub_request(:get, 'https://oauth2.googleapis.com/revoke' \
-                         '?token=accesstoken')
+      stub_request(:post, 'https://oauth2.googleapis.com/revoke')
+        .with(body: hash_including('token' => 'accesstoken'))
         .to_return(status: 200,
                    headers: { 'Content-Type' => 'application/json' })
     end
@@ -280,8 +280,8 @@ describe Google::Auth::UserRefreshCredentials do
 
   describe 'when revoking an invalid token' do
     let(:stub) do
-      stub_request(:get, 'https://oauth2.googleapis.com/revoke' \
-                         '?token=refreshtoken')
+      stub_request(:post, 'https://oauth2.googleapis.com/revoke')
+        .with(body: hash_including('token' => 'refreshtoken'))
         .to_return(status: 400,
                    headers: { 'Content-Type' => 'application/json' })
     end
@@ -296,14 +296,14 @@ describe Google::Auth::UserRefreshCredentials do
 
   describe 'when errors occurred with request' do
     it 'should fail with Signet::AuthorizationError if request times out' do
-      allow_any_instance_of(Faraday::Connection).to receive(:get)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
         .and_raise(Faraday::TimeoutError)
       expect { @client.revoke! }
         .to raise_error Signet::AuthorizationError
     end
 
     it 'should fail with Signet::AuthorizationError if request fails' do
-      allow_any_instance_of(Faraday::Connection).to receive(:get)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
         .and_raise(Faraday::ConnectionFailed, nil)
       expect { @client.revoke! }
         .to raise_error Signet::AuthorizationError


### PR DESCRIPTION
Looks like https://github.com/google/google-auth-library-ruby/pull/147/files has changed the auth [revocation URL](https://github.com/google/google-auth-library-ruby/blob/43d175f65847e7235e4a7964446443d3b42ea20f/lib/googleauth/user_refresh.rb#L51) from `https://accounts.google.com/o/oauth2/revoke` to `https://oauth2.googleapis.com/revoke` and the new URL seems to respond with a 404. This is because [/revoke should be invoked with a POST](https://github.com/GoogleCloudPlatform/google-cloud-common/issues/260#issuecomment-413232751).

Update The HTTP method for /revoke to be a POST.